### PR TITLE
Mutualized heartbeats

### DIFF
--- a/src/main/java/io/tortuga/TortugaGrpc.java
+++ b/src/main/java/io/tortuga/TortugaGrpc.java
@@ -81,23 +81,23 @@ public final class TortugaGrpc {
      return getRequestTaskMethod;
   }
 
-  private static volatile io.grpc.MethodDescriptor<io.tortuga.TortugaProto.Worker,
+  private static volatile io.grpc.MethodDescriptor<io.tortuga.TortugaProto.HeartbeatReq,
       com.google.protobuf.Empty> getHeartbeatMethod;
 
-  public static io.grpc.MethodDescriptor<io.tortuga.TortugaProto.Worker,
+  public static io.grpc.MethodDescriptor<io.tortuga.TortugaProto.HeartbeatReq,
       com.google.protobuf.Empty> getHeartbeatMethod() {
-    io.grpc.MethodDescriptor<io.tortuga.TortugaProto.Worker, com.google.protobuf.Empty> getHeartbeatMethod;
+    io.grpc.MethodDescriptor<io.tortuga.TortugaProto.HeartbeatReq, com.google.protobuf.Empty> getHeartbeatMethod;
     if ((getHeartbeatMethod = TortugaGrpc.getHeartbeatMethod) == null) {
       synchronized (TortugaGrpc.class) {
         if ((getHeartbeatMethod = TortugaGrpc.getHeartbeatMethod) == null) {
           TortugaGrpc.getHeartbeatMethod = getHeartbeatMethod = 
-              io.grpc.MethodDescriptor.<io.tortuga.TortugaProto.Worker, com.google.protobuf.Empty>newBuilder()
+              io.grpc.MethodDescriptor.<io.tortuga.TortugaProto.HeartbeatReq, com.google.protobuf.Empty>newBuilder()
               .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
               .setFullMethodName(generateFullMethodName(
                   "tortuga.Tortuga", "Heartbeat"))
               .setSampledToLocalTracing(true)
               .setRequestMarshaller(io.grpc.protobuf.ProtoUtils.marshaller(
-                  io.tortuga.TortugaProto.Worker.getDefaultInstance()))
+                  io.tortuga.TortugaProto.HeartbeatReq.getDefaultInstance()))
               .setResponseMarshaller(io.grpc.protobuf.ProtoUtils.marshaller(
                   com.google.protobuf.Empty.getDefaultInstance()))
                   .setSchemaDescriptor(new TortugaMethodDescriptorSupplier("Heartbeat"))
@@ -313,7 +313,7 @@ public final class TortugaGrpc {
 
     /**
      */
-    public void heartbeat(io.tortuga.TortugaProto.Worker request,
+    public void heartbeat(io.tortuga.TortugaProto.HeartbeatReq request,
         io.grpc.stub.StreamObserver<com.google.protobuf.Empty> responseObserver) {
       asyncUnimplementedUnaryCall(getHeartbeatMethod(), responseObserver);
     }
@@ -389,7 +389,7 @@ public final class TortugaGrpc {
             getHeartbeatMethod(),
             asyncUnaryCall(
               new MethodHandlers<
-                io.tortuga.TortugaProto.Worker,
+                io.tortuga.TortugaProto.HeartbeatReq,
                 com.google.protobuf.Empty>(
                   this, METHODID_HEARTBEAT)))
           .addMethod(
@@ -474,7 +474,7 @@ public final class TortugaGrpc {
 
     /**
      */
-    public void heartbeat(io.tortuga.TortugaProto.Worker request,
+    public void heartbeat(io.tortuga.TortugaProto.HeartbeatReq request,
         io.grpc.stub.StreamObserver<com.google.protobuf.Empty> responseObserver) {
       asyncUnaryCall(
           getChannel().newCall(getHeartbeatMethod(), getCallOptions()), request, responseObserver);
@@ -572,7 +572,7 @@ public final class TortugaGrpc {
 
     /**
      */
-    public com.google.protobuf.Empty heartbeat(io.tortuga.TortugaProto.Worker request) {
+    public com.google.protobuf.Empty heartbeat(io.tortuga.TortugaProto.HeartbeatReq request) {
       return blockingUnaryCall(
           getChannel(), getHeartbeatMethod(), getCallOptions(), request);
     }
@@ -666,7 +666,7 @@ public final class TortugaGrpc {
     /**
      */
     public com.google.common.util.concurrent.ListenableFuture<com.google.protobuf.Empty> heartbeat(
-        io.tortuga.TortugaProto.Worker request) {
+        io.tortuga.TortugaProto.HeartbeatReq request) {
       return futureUnaryCall(
           getChannel().newCall(getHeartbeatMethod(), getCallOptions()), request);
     }
@@ -765,7 +765,7 @@ public final class TortugaGrpc {
               (io.grpc.stub.StreamObserver<io.tortuga.TortugaProto.TaskResp>) responseObserver);
           break;
         case METHODID_HEARTBEAT:
-          serviceImpl.heartbeat((io.tortuga.TortugaProto.Worker) request,
+          serviceImpl.heartbeat((io.tortuga.TortugaProto.HeartbeatReq) request,
               (io.grpc.stub.StreamObserver<com.google.protobuf.Empty>) responseObserver);
           break;
         case METHODID_COMPLETE_TASK:

--- a/src/main/java/io/tortuga/TortugaProto.java
+++ b/src/main/java/io/tortuga/TortugaProto.java
@@ -938,62 +938,48 @@ public final class TortugaProto {
 
   }
 
-  public interface HeartbeatOrBuilder extends
-      // @@protoc_insertion_point(interface_extends:tortuga.Heartbeat)
+  public interface HeartbeatReqOrBuilder extends
+      // @@protoc_insertion_point(interface_extends:tortuga.HeartbeatReq)
       com.google.protobuf.MessageOrBuilder {
 
     /**
-     * <code>.tortuga.Worker worker = 1;</code>
+     * <code>repeated .tortuga.HeartbeatReq.WorkerBeat worker_beats = 1;</code>
      */
-    boolean hasWorker();
+    java.util.List<io.tortuga.TortugaProto.HeartbeatReq.WorkerBeat> 
+        getWorkerBeatsList();
     /**
-     * <code>.tortuga.Worker worker = 1;</code>
+     * <code>repeated .tortuga.HeartbeatReq.WorkerBeat worker_beats = 1;</code>
      */
-    io.tortuga.TortugaProto.Worker getWorker();
+    io.tortuga.TortugaProto.HeartbeatReq.WorkerBeat getWorkerBeats(int index);
     /**
-     * <code>.tortuga.Worker worker = 1;</code>
+     * <code>repeated .tortuga.HeartbeatReq.WorkerBeat worker_beats = 1;</code>
      */
-    io.tortuga.TortugaProto.WorkerOrBuilder getWorkerOrBuilder();
-
+    int getWorkerBeatsCount();
     /**
-     * <pre>
-     * They must be sorted!
-     * </pre>
-     *
-     * <code>repeated int64 current_task_handles = 2;</code>
+     * <code>repeated .tortuga.HeartbeatReq.WorkerBeat worker_beats = 1;</code>
      */
-    java.util.List<java.lang.Long> getCurrentTaskHandlesList();
+    java.util.List<? extends io.tortuga.TortugaProto.HeartbeatReq.WorkerBeatOrBuilder> 
+        getWorkerBeatsOrBuilderList();
     /**
-     * <pre>
-     * They must be sorted!
-     * </pre>
-     *
-     * <code>repeated int64 current_task_handles = 2;</code>
+     * <code>repeated .tortuga.HeartbeatReq.WorkerBeat worker_beats = 1;</code>
      */
-    int getCurrentTaskHandlesCount();
-    /**
-     * <pre>
-     * They must be sorted!
-     * </pre>
-     *
-     * <code>repeated int64 current_task_handles = 2;</code>
-     */
-    long getCurrentTaskHandles(int index);
+    io.tortuga.TortugaProto.HeartbeatReq.WorkerBeatOrBuilder getWorkerBeatsOrBuilder(
+        int index);
   }
   /**
-   * Protobuf type {@code tortuga.Heartbeat}
+   * Protobuf type {@code tortuga.HeartbeatReq}
    */
-  public  static final class Heartbeat extends
+  public  static final class HeartbeatReq extends
       com.google.protobuf.GeneratedMessageV3 implements
-      // @@protoc_insertion_point(message_implements:tortuga.Heartbeat)
-      HeartbeatOrBuilder {
+      // @@protoc_insertion_point(message_implements:tortuga.HeartbeatReq)
+      HeartbeatReqOrBuilder {
   private static final long serialVersionUID = 0L;
-    // Use Heartbeat.newBuilder() to construct.
-    private Heartbeat(com.google.protobuf.GeneratedMessageV3.Builder<?> builder) {
+    // Use HeartbeatReq.newBuilder() to construct.
+    private HeartbeatReq(com.google.protobuf.GeneratedMessageV3.Builder<?> builder) {
       super(builder);
     }
-    private Heartbeat() {
-      currentTaskHandles_ = java.util.Collections.emptyList();
+    private HeartbeatReq() {
+      workerBeats_ = java.util.Collections.emptyList();
     }
 
     @java.lang.Override
@@ -1001,7 +987,7 @@ public final class TortugaProto {
     getUnknownFields() {
       return this.unknownFields;
     }
-    private Heartbeat(
+    private HeartbeatReq(
         com.google.protobuf.CodedInputStream input,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws com.google.protobuf.InvalidProtocolBufferException {
@@ -1028,37 +1014,12 @@ public final class TortugaProto {
               break;
             }
             case 10: {
-              io.tortuga.TortugaProto.Worker.Builder subBuilder = null;
-              if (worker_ != null) {
-                subBuilder = worker_.toBuilder();
+              if (!((mutable_bitField0_ & 0x00000001) == 0x00000001)) {
+                workerBeats_ = new java.util.ArrayList<io.tortuga.TortugaProto.HeartbeatReq.WorkerBeat>();
+                mutable_bitField0_ |= 0x00000001;
               }
-              worker_ = input.readMessage(io.tortuga.TortugaProto.Worker.parser(), extensionRegistry);
-              if (subBuilder != null) {
-                subBuilder.mergeFrom(worker_);
-                worker_ = subBuilder.buildPartial();
-              }
-
-              break;
-            }
-            case 16: {
-              if (!((mutable_bitField0_ & 0x00000002) == 0x00000002)) {
-                currentTaskHandles_ = new java.util.ArrayList<java.lang.Long>();
-                mutable_bitField0_ |= 0x00000002;
-              }
-              currentTaskHandles_.add(input.readInt64());
-              break;
-            }
-            case 18: {
-              int length = input.readRawVarint32();
-              int limit = input.pushLimit(length);
-              if (!((mutable_bitField0_ & 0x00000002) == 0x00000002) && input.getBytesUntilLimit() > 0) {
-                currentTaskHandles_ = new java.util.ArrayList<java.lang.Long>();
-                mutable_bitField0_ |= 0x00000002;
-              }
-              while (input.getBytesUntilLimit() > 0) {
-                currentTaskHandles_.add(input.readInt64());
-              }
-              input.popLimit(limit);
+              workerBeats_.add(
+                  input.readMessage(io.tortuga.TortugaProto.HeartbeatReq.WorkerBeat.parser(), extensionRegistry));
               break;
             }
           }
@@ -1069,8 +1030,8 @@ public final class TortugaProto {
         throw new com.google.protobuf.InvalidProtocolBufferException(
             e).setUnfinishedMessage(this);
       } finally {
-        if (((mutable_bitField0_ & 0x00000002) == 0x00000002)) {
-          currentTaskHandles_ = java.util.Collections.unmodifiableList(currentTaskHandles_);
+        if (((mutable_bitField0_ & 0x00000001) == 0x00000001)) {
+          workerBeats_ = java.util.Collections.unmodifiableList(workerBeats_);
         }
         this.unknownFields = unknownFields.build();
         makeExtensionsImmutable();
@@ -1078,72 +1039,871 @@ public final class TortugaProto {
     }
     public static final com.google.protobuf.Descriptors.Descriptor
         getDescriptor() {
-      return io.tortuga.TortugaProto.internal_static_tortuga_Heartbeat_descriptor;
+      return io.tortuga.TortugaProto.internal_static_tortuga_HeartbeatReq_descriptor;
     }
 
     protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
         internalGetFieldAccessorTable() {
-      return io.tortuga.TortugaProto.internal_static_tortuga_Heartbeat_fieldAccessorTable
+      return io.tortuga.TortugaProto.internal_static_tortuga_HeartbeatReq_fieldAccessorTable
           .ensureFieldAccessorsInitialized(
-              io.tortuga.TortugaProto.Heartbeat.class, io.tortuga.TortugaProto.Heartbeat.Builder.class);
+              io.tortuga.TortugaProto.HeartbeatReq.class, io.tortuga.TortugaProto.HeartbeatReq.Builder.class);
     }
 
-    private int bitField0_;
-    public static final int WORKER_FIELD_NUMBER = 1;
-    private io.tortuga.TortugaProto.Worker worker_;
-    /**
-     * <code>.tortuga.Worker worker = 1;</code>
-     */
-    public boolean hasWorker() {
-      return worker_ != null;
+    public interface WorkerBeatOrBuilder extends
+        // @@protoc_insertion_point(interface_extends:tortuga.HeartbeatReq.WorkerBeat)
+        com.google.protobuf.MessageOrBuilder {
+
+      /**
+       * <code>.tortuga.Worker worker = 1;</code>
+       */
+      boolean hasWorker();
+      /**
+       * <code>.tortuga.Worker worker = 1;</code>
+       */
+      io.tortuga.TortugaProto.Worker getWorker();
+      /**
+       * <code>.tortuga.Worker worker = 1;</code>
+       */
+      io.tortuga.TortugaProto.WorkerOrBuilder getWorkerOrBuilder();
+
+      /**
+       * <pre>
+       * They must be sorted!
+       * </pre>
+       *
+       * <code>repeated int64 current_task_handles = 2;</code>
+       */
+      java.util.List<java.lang.Long> getCurrentTaskHandlesList();
+      /**
+       * <pre>
+       * They must be sorted!
+       * </pre>
+       *
+       * <code>repeated int64 current_task_handles = 2;</code>
+       */
+      int getCurrentTaskHandlesCount();
+      /**
+       * <pre>
+       * They must be sorted!
+       * </pre>
+       *
+       * <code>repeated int64 current_task_handles = 2;</code>
+       */
+      long getCurrentTaskHandles(int index);
     }
     /**
-     * <code>.tortuga.Worker worker = 1;</code>
+     * <pre>
+     * a connection handling multiple workers will beat for all of them at once
+     * hence this is repeated.
+     * </pre>
+     *
+     * Protobuf type {@code tortuga.HeartbeatReq.WorkerBeat}
      */
-    public io.tortuga.TortugaProto.Worker getWorker() {
-      return worker_ == null ? io.tortuga.TortugaProto.Worker.getDefaultInstance() : worker_;
-    }
-    /**
-     * <code>.tortuga.Worker worker = 1;</code>
-     */
-    public io.tortuga.TortugaProto.WorkerOrBuilder getWorkerOrBuilder() {
-      return getWorker();
+    public  static final class WorkerBeat extends
+        com.google.protobuf.GeneratedMessageV3 implements
+        // @@protoc_insertion_point(message_implements:tortuga.HeartbeatReq.WorkerBeat)
+        WorkerBeatOrBuilder {
+    private static final long serialVersionUID = 0L;
+      // Use WorkerBeat.newBuilder() to construct.
+      private WorkerBeat(com.google.protobuf.GeneratedMessageV3.Builder<?> builder) {
+        super(builder);
+      }
+      private WorkerBeat() {
+        currentTaskHandles_ = java.util.Collections.emptyList();
+      }
+
+      @java.lang.Override
+      public final com.google.protobuf.UnknownFieldSet
+      getUnknownFields() {
+        return this.unknownFields;
+      }
+      private WorkerBeat(
+          com.google.protobuf.CodedInputStream input,
+          com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+          throws com.google.protobuf.InvalidProtocolBufferException {
+        this();
+        if (extensionRegistry == null) {
+          throw new java.lang.NullPointerException();
+        }
+        int mutable_bitField0_ = 0;
+        com.google.protobuf.UnknownFieldSet.Builder unknownFields =
+            com.google.protobuf.UnknownFieldSet.newBuilder();
+        try {
+          boolean done = false;
+          while (!done) {
+            int tag = input.readTag();
+            switch (tag) {
+              case 0:
+                done = true;
+                break;
+              default: {
+                if (!parseUnknownFieldProto3(
+                    input, unknownFields, extensionRegistry, tag)) {
+                  done = true;
+                }
+                break;
+              }
+              case 10: {
+                io.tortuga.TortugaProto.Worker.Builder subBuilder = null;
+                if (worker_ != null) {
+                  subBuilder = worker_.toBuilder();
+                }
+                worker_ = input.readMessage(io.tortuga.TortugaProto.Worker.parser(), extensionRegistry);
+                if (subBuilder != null) {
+                  subBuilder.mergeFrom(worker_);
+                  worker_ = subBuilder.buildPartial();
+                }
+
+                break;
+              }
+              case 16: {
+                if (!((mutable_bitField0_ & 0x00000002) == 0x00000002)) {
+                  currentTaskHandles_ = new java.util.ArrayList<java.lang.Long>();
+                  mutable_bitField0_ |= 0x00000002;
+                }
+                currentTaskHandles_.add(input.readInt64());
+                break;
+              }
+              case 18: {
+                int length = input.readRawVarint32();
+                int limit = input.pushLimit(length);
+                if (!((mutable_bitField0_ & 0x00000002) == 0x00000002) && input.getBytesUntilLimit() > 0) {
+                  currentTaskHandles_ = new java.util.ArrayList<java.lang.Long>();
+                  mutable_bitField0_ |= 0x00000002;
+                }
+                while (input.getBytesUntilLimit() > 0) {
+                  currentTaskHandles_.add(input.readInt64());
+                }
+                input.popLimit(limit);
+                break;
+              }
+            }
+          }
+        } catch (com.google.protobuf.InvalidProtocolBufferException e) {
+          throw e.setUnfinishedMessage(this);
+        } catch (java.io.IOException e) {
+          throw new com.google.protobuf.InvalidProtocolBufferException(
+              e).setUnfinishedMessage(this);
+        } finally {
+          if (((mutable_bitField0_ & 0x00000002) == 0x00000002)) {
+            currentTaskHandles_ = java.util.Collections.unmodifiableList(currentTaskHandles_);
+          }
+          this.unknownFields = unknownFields.build();
+          makeExtensionsImmutable();
+        }
+      }
+      public static final com.google.protobuf.Descriptors.Descriptor
+          getDescriptor() {
+        return io.tortuga.TortugaProto.internal_static_tortuga_HeartbeatReq_WorkerBeat_descriptor;
+      }
+
+      protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
+          internalGetFieldAccessorTable() {
+        return io.tortuga.TortugaProto.internal_static_tortuga_HeartbeatReq_WorkerBeat_fieldAccessorTable
+            .ensureFieldAccessorsInitialized(
+                io.tortuga.TortugaProto.HeartbeatReq.WorkerBeat.class, io.tortuga.TortugaProto.HeartbeatReq.WorkerBeat.Builder.class);
+      }
+
+      private int bitField0_;
+      public static final int WORKER_FIELD_NUMBER = 1;
+      private io.tortuga.TortugaProto.Worker worker_;
+      /**
+       * <code>.tortuga.Worker worker = 1;</code>
+       */
+      public boolean hasWorker() {
+        return worker_ != null;
+      }
+      /**
+       * <code>.tortuga.Worker worker = 1;</code>
+       */
+      public io.tortuga.TortugaProto.Worker getWorker() {
+        return worker_ == null ? io.tortuga.TortugaProto.Worker.getDefaultInstance() : worker_;
+      }
+      /**
+       * <code>.tortuga.Worker worker = 1;</code>
+       */
+      public io.tortuga.TortugaProto.WorkerOrBuilder getWorkerOrBuilder() {
+        return getWorker();
+      }
+
+      public static final int CURRENT_TASK_HANDLES_FIELD_NUMBER = 2;
+      private java.util.List<java.lang.Long> currentTaskHandles_;
+      /**
+       * <pre>
+       * They must be sorted!
+       * </pre>
+       *
+       * <code>repeated int64 current_task_handles = 2;</code>
+       */
+      public java.util.List<java.lang.Long>
+          getCurrentTaskHandlesList() {
+        return currentTaskHandles_;
+      }
+      /**
+       * <pre>
+       * They must be sorted!
+       * </pre>
+       *
+       * <code>repeated int64 current_task_handles = 2;</code>
+       */
+      public int getCurrentTaskHandlesCount() {
+        return currentTaskHandles_.size();
+      }
+      /**
+       * <pre>
+       * They must be sorted!
+       * </pre>
+       *
+       * <code>repeated int64 current_task_handles = 2;</code>
+       */
+      public long getCurrentTaskHandles(int index) {
+        return currentTaskHandles_.get(index);
+      }
+      private int currentTaskHandlesMemoizedSerializedSize = -1;
+
+      private byte memoizedIsInitialized = -1;
+      public final boolean isInitialized() {
+        byte isInitialized = memoizedIsInitialized;
+        if (isInitialized == 1) return true;
+        if (isInitialized == 0) return false;
+
+        memoizedIsInitialized = 1;
+        return true;
+      }
+
+      public void writeTo(com.google.protobuf.CodedOutputStream output)
+                          throws java.io.IOException {
+        getSerializedSize();
+        if (worker_ != null) {
+          output.writeMessage(1, getWorker());
+        }
+        if (getCurrentTaskHandlesList().size() > 0) {
+          output.writeUInt32NoTag(18);
+          output.writeUInt32NoTag(currentTaskHandlesMemoizedSerializedSize);
+        }
+        for (int i = 0; i < currentTaskHandles_.size(); i++) {
+          output.writeInt64NoTag(currentTaskHandles_.get(i));
+        }
+        unknownFields.writeTo(output);
+      }
+
+      public int getSerializedSize() {
+        int size = memoizedSize;
+        if (size != -1) return size;
+
+        size = 0;
+        if (worker_ != null) {
+          size += com.google.protobuf.CodedOutputStream
+            .computeMessageSize(1, getWorker());
+        }
+        {
+          int dataSize = 0;
+          for (int i = 0; i < currentTaskHandles_.size(); i++) {
+            dataSize += com.google.protobuf.CodedOutputStream
+              .computeInt64SizeNoTag(currentTaskHandles_.get(i));
+          }
+          size += dataSize;
+          if (!getCurrentTaskHandlesList().isEmpty()) {
+            size += 1;
+            size += com.google.protobuf.CodedOutputStream
+                .computeInt32SizeNoTag(dataSize);
+          }
+          currentTaskHandlesMemoizedSerializedSize = dataSize;
+        }
+        size += unknownFields.getSerializedSize();
+        memoizedSize = size;
+        return size;
+      }
+
+      @java.lang.Override
+      public boolean equals(final java.lang.Object obj) {
+        if (obj == this) {
+         return true;
+        }
+        if (!(obj instanceof io.tortuga.TortugaProto.HeartbeatReq.WorkerBeat)) {
+          return super.equals(obj);
+        }
+        io.tortuga.TortugaProto.HeartbeatReq.WorkerBeat other = (io.tortuga.TortugaProto.HeartbeatReq.WorkerBeat) obj;
+
+        boolean result = true;
+        result = result && (hasWorker() == other.hasWorker());
+        if (hasWorker()) {
+          result = result && getWorker()
+              .equals(other.getWorker());
+        }
+        result = result && getCurrentTaskHandlesList()
+            .equals(other.getCurrentTaskHandlesList());
+        result = result && unknownFields.equals(other.unknownFields);
+        return result;
+      }
+
+      @java.lang.Override
+      public int hashCode() {
+        if (memoizedHashCode != 0) {
+          return memoizedHashCode;
+        }
+        int hash = 41;
+        hash = (19 * hash) + getDescriptor().hashCode();
+        if (hasWorker()) {
+          hash = (37 * hash) + WORKER_FIELD_NUMBER;
+          hash = (53 * hash) + getWorker().hashCode();
+        }
+        if (getCurrentTaskHandlesCount() > 0) {
+          hash = (37 * hash) + CURRENT_TASK_HANDLES_FIELD_NUMBER;
+          hash = (53 * hash) + getCurrentTaskHandlesList().hashCode();
+        }
+        hash = (29 * hash) + unknownFields.hashCode();
+        memoizedHashCode = hash;
+        return hash;
+      }
+
+      public static io.tortuga.TortugaProto.HeartbeatReq.WorkerBeat parseFrom(
+          java.nio.ByteBuffer data)
+          throws com.google.protobuf.InvalidProtocolBufferException {
+        return PARSER.parseFrom(data);
+      }
+      public static io.tortuga.TortugaProto.HeartbeatReq.WorkerBeat parseFrom(
+          java.nio.ByteBuffer data,
+          com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+          throws com.google.protobuf.InvalidProtocolBufferException {
+        return PARSER.parseFrom(data, extensionRegistry);
+      }
+      public static io.tortuga.TortugaProto.HeartbeatReq.WorkerBeat parseFrom(
+          com.google.protobuf.ByteString data)
+          throws com.google.protobuf.InvalidProtocolBufferException {
+        return PARSER.parseFrom(data);
+      }
+      public static io.tortuga.TortugaProto.HeartbeatReq.WorkerBeat parseFrom(
+          com.google.protobuf.ByteString data,
+          com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+          throws com.google.protobuf.InvalidProtocolBufferException {
+        return PARSER.parseFrom(data, extensionRegistry);
+      }
+      public static io.tortuga.TortugaProto.HeartbeatReq.WorkerBeat parseFrom(byte[] data)
+          throws com.google.protobuf.InvalidProtocolBufferException {
+        return PARSER.parseFrom(data);
+      }
+      public static io.tortuga.TortugaProto.HeartbeatReq.WorkerBeat parseFrom(
+          byte[] data,
+          com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+          throws com.google.protobuf.InvalidProtocolBufferException {
+        return PARSER.parseFrom(data, extensionRegistry);
+      }
+      public static io.tortuga.TortugaProto.HeartbeatReq.WorkerBeat parseFrom(java.io.InputStream input)
+          throws java.io.IOException {
+        return com.google.protobuf.GeneratedMessageV3
+            .parseWithIOException(PARSER, input);
+      }
+      public static io.tortuga.TortugaProto.HeartbeatReq.WorkerBeat parseFrom(
+          java.io.InputStream input,
+          com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+          throws java.io.IOException {
+        return com.google.protobuf.GeneratedMessageV3
+            .parseWithIOException(PARSER, input, extensionRegistry);
+      }
+      public static io.tortuga.TortugaProto.HeartbeatReq.WorkerBeat parseDelimitedFrom(java.io.InputStream input)
+          throws java.io.IOException {
+        return com.google.protobuf.GeneratedMessageV3
+            .parseDelimitedWithIOException(PARSER, input);
+      }
+      public static io.tortuga.TortugaProto.HeartbeatReq.WorkerBeat parseDelimitedFrom(
+          java.io.InputStream input,
+          com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+          throws java.io.IOException {
+        return com.google.protobuf.GeneratedMessageV3
+            .parseDelimitedWithIOException(PARSER, input, extensionRegistry);
+      }
+      public static io.tortuga.TortugaProto.HeartbeatReq.WorkerBeat parseFrom(
+          com.google.protobuf.CodedInputStream input)
+          throws java.io.IOException {
+        return com.google.protobuf.GeneratedMessageV3
+            .parseWithIOException(PARSER, input);
+      }
+      public static io.tortuga.TortugaProto.HeartbeatReq.WorkerBeat parseFrom(
+          com.google.protobuf.CodedInputStream input,
+          com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+          throws java.io.IOException {
+        return com.google.protobuf.GeneratedMessageV3
+            .parseWithIOException(PARSER, input, extensionRegistry);
+      }
+
+      public Builder newBuilderForType() { return newBuilder(); }
+      public static Builder newBuilder() {
+        return DEFAULT_INSTANCE.toBuilder();
+      }
+      public static Builder newBuilder(io.tortuga.TortugaProto.HeartbeatReq.WorkerBeat prototype) {
+        return DEFAULT_INSTANCE.toBuilder().mergeFrom(prototype);
+      }
+      public Builder toBuilder() {
+        return this == DEFAULT_INSTANCE
+            ? new Builder() : new Builder().mergeFrom(this);
+      }
+
+      @java.lang.Override
+      protected Builder newBuilderForType(
+          com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
+        Builder builder = new Builder(parent);
+        return builder;
+      }
+      /**
+       * <pre>
+       * a connection handling multiple workers will beat for all of them at once
+       * hence this is repeated.
+       * </pre>
+       *
+       * Protobuf type {@code tortuga.HeartbeatReq.WorkerBeat}
+       */
+      public static final class Builder extends
+          com.google.protobuf.GeneratedMessageV3.Builder<Builder> implements
+          // @@protoc_insertion_point(builder_implements:tortuga.HeartbeatReq.WorkerBeat)
+          io.tortuga.TortugaProto.HeartbeatReq.WorkerBeatOrBuilder {
+        public static final com.google.protobuf.Descriptors.Descriptor
+            getDescriptor() {
+          return io.tortuga.TortugaProto.internal_static_tortuga_HeartbeatReq_WorkerBeat_descriptor;
+        }
+
+        protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
+            internalGetFieldAccessorTable() {
+          return io.tortuga.TortugaProto.internal_static_tortuga_HeartbeatReq_WorkerBeat_fieldAccessorTable
+              .ensureFieldAccessorsInitialized(
+                  io.tortuga.TortugaProto.HeartbeatReq.WorkerBeat.class, io.tortuga.TortugaProto.HeartbeatReq.WorkerBeat.Builder.class);
+        }
+
+        // Construct using io.tortuga.TortugaProto.HeartbeatReq.WorkerBeat.newBuilder()
+        private Builder() {
+          maybeForceBuilderInitialization();
+        }
+
+        private Builder(
+            com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
+          super(parent);
+          maybeForceBuilderInitialization();
+        }
+        private void maybeForceBuilderInitialization() {
+          if (com.google.protobuf.GeneratedMessageV3
+                  .alwaysUseFieldBuilders) {
+          }
+        }
+        public Builder clear() {
+          super.clear();
+          if (workerBuilder_ == null) {
+            worker_ = null;
+          } else {
+            worker_ = null;
+            workerBuilder_ = null;
+          }
+          currentTaskHandles_ = java.util.Collections.emptyList();
+          bitField0_ = (bitField0_ & ~0x00000002);
+          return this;
+        }
+
+        public com.google.protobuf.Descriptors.Descriptor
+            getDescriptorForType() {
+          return io.tortuga.TortugaProto.internal_static_tortuga_HeartbeatReq_WorkerBeat_descriptor;
+        }
+
+        public io.tortuga.TortugaProto.HeartbeatReq.WorkerBeat getDefaultInstanceForType() {
+          return io.tortuga.TortugaProto.HeartbeatReq.WorkerBeat.getDefaultInstance();
+        }
+
+        public io.tortuga.TortugaProto.HeartbeatReq.WorkerBeat build() {
+          io.tortuga.TortugaProto.HeartbeatReq.WorkerBeat result = buildPartial();
+          if (!result.isInitialized()) {
+            throw newUninitializedMessageException(result);
+          }
+          return result;
+        }
+
+        public io.tortuga.TortugaProto.HeartbeatReq.WorkerBeat buildPartial() {
+          io.tortuga.TortugaProto.HeartbeatReq.WorkerBeat result = new io.tortuga.TortugaProto.HeartbeatReq.WorkerBeat(this);
+          int from_bitField0_ = bitField0_;
+          int to_bitField0_ = 0;
+          if (workerBuilder_ == null) {
+            result.worker_ = worker_;
+          } else {
+            result.worker_ = workerBuilder_.build();
+          }
+          if (((bitField0_ & 0x00000002) == 0x00000002)) {
+            currentTaskHandles_ = java.util.Collections.unmodifiableList(currentTaskHandles_);
+            bitField0_ = (bitField0_ & ~0x00000002);
+          }
+          result.currentTaskHandles_ = currentTaskHandles_;
+          result.bitField0_ = to_bitField0_;
+          onBuilt();
+          return result;
+        }
+
+        public Builder clone() {
+          return (Builder) super.clone();
+        }
+        public Builder setField(
+            com.google.protobuf.Descriptors.FieldDescriptor field,
+            java.lang.Object value) {
+          return (Builder) super.setField(field, value);
+        }
+        public Builder clearField(
+            com.google.protobuf.Descriptors.FieldDescriptor field) {
+          return (Builder) super.clearField(field);
+        }
+        public Builder clearOneof(
+            com.google.protobuf.Descriptors.OneofDescriptor oneof) {
+          return (Builder) super.clearOneof(oneof);
+        }
+        public Builder setRepeatedField(
+            com.google.protobuf.Descriptors.FieldDescriptor field,
+            int index, java.lang.Object value) {
+          return (Builder) super.setRepeatedField(field, index, value);
+        }
+        public Builder addRepeatedField(
+            com.google.protobuf.Descriptors.FieldDescriptor field,
+            java.lang.Object value) {
+          return (Builder) super.addRepeatedField(field, value);
+        }
+        public Builder mergeFrom(com.google.protobuf.Message other) {
+          if (other instanceof io.tortuga.TortugaProto.HeartbeatReq.WorkerBeat) {
+            return mergeFrom((io.tortuga.TortugaProto.HeartbeatReq.WorkerBeat)other);
+          } else {
+            super.mergeFrom(other);
+            return this;
+          }
+        }
+
+        public Builder mergeFrom(io.tortuga.TortugaProto.HeartbeatReq.WorkerBeat other) {
+          if (other == io.tortuga.TortugaProto.HeartbeatReq.WorkerBeat.getDefaultInstance()) return this;
+          if (other.hasWorker()) {
+            mergeWorker(other.getWorker());
+          }
+          if (!other.currentTaskHandles_.isEmpty()) {
+            if (currentTaskHandles_.isEmpty()) {
+              currentTaskHandles_ = other.currentTaskHandles_;
+              bitField0_ = (bitField0_ & ~0x00000002);
+            } else {
+              ensureCurrentTaskHandlesIsMutable();
+              currentTaskHandles_.addAll(other.currentTaskHandles_);
+            }
+            onChanged();
+          }
+          this.mergeUnknownFields(other.unknownFields);
+          onChanged();
+          return this;
+        }
+
+        public final boolean isInitialized() {
+          return true;
+        }
+
+        public Builder mergeFrom(
+            com.google.protobuf.CodedInputStream input,
+            com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+            throws java.io.IOException {
+          io.tortuga.TortugaProto.HeartbeatReq.WorkerBeat parsedMessage = null;
+          try {
+            parsedMessage = PARSER.parsePartialFrom(input, extensionRegistry);
+          } catch (com.google.protobuf.InvalidProtocolBufferException e) {
+            parsedMessage = (io.tortuga.TortugaProto.HeartbeatReq.WorkerBeat) e.getUnfinishedMessage();
+            throw e.unwrapIOException();
+          } finally {
+            if (parsedMessage != null) {
+              mergeFrom(parsedMessage);
+            }
+          }
+          return this;
+        }
+        private int bitField0_;
+
+        private io.tortuga.TortugaProto.Worker worker_ = null;
+        private com.google.protobuf.SingleFieldBuilderV3<
+            io.tortuga.TortugaProto.Worker, io.tortuga.TortugaProto.Worker.Builder, io.tortuga.TortugaProto.WorkerOrBuilder> workerBuilder_;
+        /**
+         * <code>.tortuga.Worker worker = 1;</code>
+         */
+        public boolean hasWorker() {
+          return workerBuilder_ != null || worker_ != null;
+        }
+        /**
+         * <code>.tortuga.Worker worker = 1;</code>
+         */
+        public io.tortuga.TortugaProto.Worker getWorker() {
+          if (workerBuilder_ == null) {
+            return worker_ == null ? io.tortuga.TortugaProto.Worker.getDefaultInstance() : worker_;
+          } else {
+            return workerBuilder_.getMessage();
+          }
+        }
+        /**
+         * <code>.tortuga.Worker worker = 1;</code>
+         */
+        public Builder setWorker(io.tortuga.TortugaProto.Worker value) {
+          if (workerBuilder_ == null) {
+            if (value == null) {
+              throw new NullPointerException();
+            }
+            worker_ = value;
+            onChanged();
+          } else {
+            workerBuilder_.setMessage(value);
+          }
+
+          return this;
+        }
+        /**
+         * <code>.tortuga.Worker worker = 1;</code>
+         */
+        public Builder setWorker(
+            io.tortuga.TortugaProto.Worker.Builder builderForValue) {
+          if (workerBuilder_ == null) {
+            worker_ = builderForValue.build();
+            onChanged();
+          } else {
+            workerBuilder_.setMessage(builderForValue.build());
+          }
+
+          return this;
+        }
+        /**
+         * <code>.tortuga.Worker worker = 1;</code>
+         */
+        public Builder mergeWorker(io.tortuga.TortugaProto.Worker value) {
+          if (workerBuilder_ == null) {
+            if (worker_ != null) {
+              worker_ =
+                io.tortuga.TortugaProto.Worker.newBuilder(worker_).mergeFrom(value).buildPartial();
+            } else {
+              worker_ = value;
+            }
+            onChanged();
+          } else {
+            workerBuilder_.mergeFrom(value);
+          }
+
+          return this;
+        }
+        /**
+         * <code>.tortuga.Worker worker = 1;</code>
+         */
+        public Builder clearWorker() {
+          if (workerBuilder_ == null) {
+            worker_ = null;
+            onChanged();
+          } else {
+            worker_ = null;
+            workerBuilder_ = null;
+          }
+
+          return this;
+        }
+        /**
+         * <code>.tortuga.Worker worker = 1;</code>
+         */
+        public io.tortuga.TortugaProto.Worker.Builder getWorkerBuilder() {
+          
+          onChanged();
+          return getWorkerFieldBuilder().getBuilder();
+        }
+        /**
+         * <code>.tortuga.Worker worker = 1;</code>
+         */
+        public io.tortuga.TortugaProto.WorkerOrBuilder getWorkerOrBuilder() {
+          if (workerBuilder_ != null) {
+            return workerBuilder_.getMessageOrBuilder();
+          } else {
+            return worker_ == null ?
+                io.tortuga.TortugaProto.Worker.getDefaultInstance() : worker_;
+          }
+        }
+        /**
+         * <code>.tortuga.Worker worker = 1;</code>
+         */
+        private com.google.protobuf.SingleFieldBuilderV3<
+            io.tortuga.TortugaProto.Worker, io.tortuga.TortugaProto.Worker.Builder, io.tortuga.TortugaProto.WorkerOrBuilder> 
+            getWorkerFieldBuilder() {
+          if (workerBuilder_ == null) {
+            workerBuilder_ = new com.google.protobuf.SingleFieldBuilderV3<
+                io.tortuga.TortugaProto.Worker, io.tortuga.TortugaProto.Worker.Builder, io.tortuga.TortugaProto.WorkerOrBuilder>(
+                    getWorker(),
+                    getParentForChildren(),
+                    isClean());
+            worker_ = null;
+          }
+          return workerBuilder_;
+        }
+
+        private java.util.List<java.lang.Long> currentTaskHandles_ = java.util.Collections.emptyList();
+        private void ensureCurrentTaskHandlesIsMutable() {
+          if (!((bitField0_ & 0x00000002) == 0x00000002)) {
+            currentTaskHandles_ = new java.util.ArrayList<java.lang.Long>(currentTaskHandles_);
+            bitField0_ |= 0x00000002;
+           }
+        }
+        /**
+         * <pre>
+         * They must be sorted!
+         * </pre>
+         *
+         * <code>repeated int64 current_task_handles = 2;</code>
+         */
+        public java.util.List<java.lang.Long>
+            getCurrentTaskHandlesList() {
+          return java.util.Collections.unmodifiableList(currentTaskHandles_);
+        }
+        /**
+         * <pre>
+         * They must be sorted!
+         * </pre>
+         *
+         * <code>repeated int64 current_task_handles = 2;</code>
+         */
+        public int getCurrentTaskHandlesCount() {
+          return currentTaskHandles_.size();
+        }
+        /**
+         * <pre>
+         * They must be sorted!
+         * </pre>
+         *
+         * <code>repeated int64 current_task_handles = 2;</code>
+         */
+        public long getCurrentTaskHandles(int index) {
+          return currentTaskHandles_.get(index);
+        }
+        /**
+         * <pre>
+         * They must be sorted!
+         * </pre>
+         *
+         * <code>repeated int64 current_task_handles = 2;</code>
+         */
+        public Builder setCurrentTaskHandles(
+            int index, long value) {
+          ensureCurrentTaskHandlesIsMutable();
+          currentTaskHandles_.set(index, value);
+          onChanged();
+          return this;
+        }
+        /**
+         * <pre>
+         * They must be sorted!
+         * </pre>
+         *
+         * <code>repeated int64 current_task_handles = 2;</code>
+         */
+        public Builder addCurrentTaskHandles(long value) {
+          ensureCurrentTaskHandlesIsMutable();
+          currentTaskHandles_.add(value);
+          onChanged();
+          return this;
+        }
+        /**
+         * <pre>
+         * They must be sorted!
+         * </pre>
+         *
+         * <code>repeated int64 current_task_handles = 2;</code>
+         */
+        public Builder addAllCurrentTaskHandles(
+            java.lang.Iterable<? extends java.lang.Long> values) {
+          ensureCurrentTaskHandlesIsMutable();
+          com.google.protobuf.AbstractMessageLite.Builder.addAll(
+              values, currentTaskHandles_);
+          onChanged();
+          return this;
+        }
+        /**
+         * <pre>
+         * They must be sorted!
+         * </pre>
+         *
+         * <code>repeated int64 current_task_handles = 2;</code>
+         */
+        public Builder clearCurrentTaskHandles() {
+          currentTaskHandles_ = java.util.Collections.emptyList();
+          bitField0_ = (bitField0_ & ~0x00000002);
+          onChanged();
+          return this;
+        }
+        public final Builder setUnknownFields(
+            final com.google.protobuf.UnknownFieldSet unknownFields) {
+          return super.setUnknownFieldsProto3(unknownFields);
+        }
+
+        public final Builder mergeUnknownFields(
+            final com.google.protobuf.UnknownFieldSet unknownFields) {
+          return super.mergeUnknownFields(unknownFields);
+        }
+
+
+        // @@protoc_insertion_point(builder_scope:tortuga.HeartbeatReq.WorkerBeat)
+      }
+
+      // @@protoc_insertion_point(class_scope:tortuga.HeartbeatReq.WorkerBeat)
+      private static final io.tortuga.TortugaProto.HeartbeatReq.WorkerBeat DEFAULT_INSTANCE;
+      static {
+        DEFAULT_INSTANCE = new io.tortuga.TortugaProto.HeartbeatReq.WorkerBeat();
+      }
+
+      public static io.tortuga.TortugaProto.HeartbeatReq.WorkerBeat getDefaultInstance() {
+        return DEFAULT_INSTANCE;
+      }
+
+      private static final com.google.protobuf.Parser<WorkerBeat>
+          PARSER = new com.google.protobuf.AbstractParser<WorkerBeat>() {
+        public WorkerBeat parsePartialFrom(
+            com.google.protobuf.CodedInputStream input,
+            com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+            throws com.google.protobuf.InvalidProtocolBufferException {
+          return new WorkerBeat(input, extensionRegistry);
+        }
+      };
+
+      public static com.google.protobuf.Parser<WorkerBeat> parser() {
+        return PARSER;
+      }
+
+      @java.lang.Override
+      public com.google.protobuf.Parser<WorkerBeat> getParserForType() {
+        return PARSER;
+      }
+
+      public io.tortuga.TortugaProto.HeartbeatReq.WorkerBeat getDefaultInstanceForType() {
+        return DEFAULT_INSTANCE;
+      }
+
     }
 
-    public static final int CURRENT_TASK_HANDLES_FIELD_NUMBER = 2;
-    private java.util.List<java.lang.Long> currentTaskHandles_;
+    public static final int WORKER_BEATS_FIELD_NUMBER = 1;
+    private java.util.List<io.tortuga.TortugaProto.HeartbeatReq.WorkerBeat> workerBeats_;
     /**
-     * <pre>
-     * They must be sorted!
-     * </pre>
-     *
-     * <code>repeated int64 current_task_handles = 2;</code>
+     * <code>repeated .tortuga.HeartbeatReq.WorkerBeat worker_beats = 1;</code>
      */
-    public java.util.List<java.lang.Long>
-        getCurrentTaskHandlesList() {
-      return currentTaskHandles_;
+    public java.util.List<io.tortuga.TortugaProto.HeartbeatReq.WorkerBeat> getWorkerBeatsList() {
+      return workerBeats_;
     }
     /**
-     * <pre>
-     * They must be sorted!
-     * </pre>
-     *
-     * <code>repeated int64 current_task_handles = 2;</code>
+     * <code>repeated .tortuga.HeartbeatReq.WorkerBeat worker_beats = 1;</code>
      */
-    public int getCurrentTaskHandlesCount() {
-      return currentTaskHandles_.size();
+    public java.util.List<? extends io.tortuga.TortugaProto.HeartbeatReq.WorkerBeatOrBuilder> 
+        getWorkerBeatsOrBuilderList() {
+      return workerBeats_;
     }
     /**
-     * <pre>
-     * They must be sorted!
-     * </pre>
-     *
-     * <code>repeated int64 current_task_handles = 2;</code>
+     * <code>repeated .tortuga.HeartbeatReq.WorkerBeat worker_beats = 1;</code>
      */
-    public long getCurrentTaskHandles(int index) {
-      return currentTaskHandles_.get(index);
+    public int getWorkerBeatsCount() {
+      return workerBeats_.size();
     }
-    private int currentTaskHandlesMemoizedSerializedSize = -1;
+    /**
+     * <code>repeated .tortuga.HeartbeatReq.WorkerBeat worker_beats = 1;</code>
+     */
+    public io.tortuga.TortugaProto.HeartbeatReq.WorkerBeat getWorkerBeats(int index) {
+      return workerBeats_.get(index);
+    }
+    /**
+     * <code>repeated .tortuga.HeartbeatReq.WorkerBeat worker_beats = 1;</code>
+     */
+    public io.tortuga.TortugaProto.HeartbeatReq.WorkerBeatOrBuilder getWorkerBeatsOrBuilder(
+        int index) {
+      return workerBeats_.get(index);
+    }
 
     private byte memoizedIsInitialized = -1;
     public final boolean isInitialized() {
@@ -1157,16 +1917,8 @@ public final class TortugaProto {
 
     public void writeTo(com.google.protobuf.CodedOutputStream output)
                         throws java.io.IOException {
-      getSerializedSize();
-      if (worker_ != null) {
-        output.writeMessage(1, getWorker());
-      }
-      if (getCurrentTaskHandlesList().size() > 0) {
-        output.writeUInt32NoTag(18);
-        output.writeUInt32NoTag(currentTaskHandlesMemoizedSerializedSize);
-      }
-      for (int i = 0; i < currentTaskHandles_.size(); i++) {
-        output.writeInt64NoTag(currentTaskHandles_.get(i));
+      for (int i = 0; i < workerBeats_.size(); i++) {
+        output.writeMessage(1, workerBeats_.get(i));
       }
       unknownFields.writeTo(output);
     }
@@ -1176,23 +1928,9 @@ public final class TortugaProto {
       if (size != -1) return size;
 
       size = 0;
-      if (worker_ != null) {
+      for (int i = 0; i < workerBeats_.size(); i++) {
         size += com.google.protobuf.CodedOutputStream
-          .computeMessageSize(1, getWorker());
-      }
-      {
-        int dataSize = 0;
-        for (int i = 0; i < currentTaskHandles_.size(); i++) {
-          dataSize += com.google.protobuf.CodedOutputStream
-            .computeInt64SizeNoTag(currentTaskHandles_.get(i));
-        }
-        size += dataSize;
-        if (!getCurrentTaskHandlesList().isEmpty()) {
-          size += 1;
-          size += com.google.protobuf.CodedOutputStream
-              .computeInt32SizeNoTag(dataSize);
-        }
-        currentTaskHandlesMemoizedSerializedSize = dataSize;
+          .computeMessageSize(1, workerBeats_.get(i));
       }
       size += unknownFields.getSerializedSize();
       memoizedSize = size;
@@ -1204,19 +1942,14 @@ public final class TortugaProto {
       if (obj == this) {
        return true;
       }
-      if (!(obj instanceof io.tortuga.TortugaProto.Heartbeat)) {
+      if (!(obj instanceof io.tortuga.TortugaProto.HeartbeatReq)) {
         return super.equals(obj);
       }
-      io.tortuga.TortugaProto.Heartbeat other = (io.tortuga.TortugaProto.Heartbeat) obj;
+      io.tortuga.TortugaProto.HeartbeatReq other = (io.tortuga.TortugaProto.HeartbeatReq) obj;
 
       boolean result = true;
-      result = result && (hasWorker() == other.hasWorker());
-      if (hasWorker()) {
-        result = result && getWorker()
-            .equals(other.getWorker());
-      }
-      result = result && getCurrentTaskHandlesList()
-          .equals(other.getCurrentTaskHandlesList());
+      result = result && getWorkerBeatsList()
+          .equals(other.getWorkerBeatsList());
       result = result && unknownFields.equals(other.unknownFields);
       return result;
     }
@@ -1228,82 +1961,78 @@ public final class TortugaProto {
       }
       int hash = 41;
       hash = (19 * hash) + getDescriptor().hashCode();
-      if (hasWorker()) {
-        hash = (37 * hash) + WORKER_FIELD_NUMBER;
-        hash = (53 * hash) + getWorker().hashCode();
-      }
-      if (getCurrentTaskHandlesCount() > 0) {
-        hash = (37 * hash) + CURRENT_TASK_HANDLES_FIELD_NUMBER;
-        hash = (53 * hash) + getCurrentTaskHandlesList().hashCode();
+      if (getWorkerBeatsCount() > 0) {
+        hash = (37 * hash) + WORKER_BEATS_FIELD_NUMBER;
+        hash = (53 * hash) + getWorkerBeatsList().hashCode();
       }
       hash = (29 * hash) + unknownFields.hashCode();
       memoizedHashCode = hash;
       return hash;
     }
 
-    public static io.tortuga.TortugaProto.Heartbeat parseFrom(
+    public static io.tortuga.TortugaProto.HeartbeatReq parseFrom(
         java.nio.ByteBuffer data)
         throws com.google.protobuf.InvalidProtocolBufferException {
       return PARSER.parseFrom(data);
     }
-    public static io.tortuga.TortugaProto.Heartbeat parseFrom(
+    public static io.tortuga.TortugaProto.HeartbeatReq parseFrom(
         java.nio.ByteBuffer data,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws com.google.protobuf.InvalidProtocolBufferException {
       return PARSER.parseFrom(data, extensionRegistry);
     }
-    public static io.tortuga.TortugaProto.Heartbeat parseFrom(
+    public static io.tortuga.TortugaProto.HeartbeatReq parseFrom(
         com.google.protobuf.ByteString data)
         throws com.google.protobuf.InvalidProtocolBufferException {
       return PARSER.parseFrom(data);
     }
-    public static io.tortuga.TortugaProto.Heartbeat parseFrom(
+    public static io.tortuga.TortugaProto.HeartbeatReq parseFrom(
         com.google.protobuf.ByteString data,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws com.google.protobuf.InvalidProtocolBufferException {
       return PARSER.parseFrom(data, extensionRegistry);
     }
-    public static io.tortuga.TortugaProto.Heartbeat parseFrom(byte[] data)
+    public static io.tortuga.TortugaProto.HeartbeatReq parseFrom(byte[] data)
         throws com.google.protobuf.InvalidProtocolBufferException {
       return PARSER.parseFrom(data);
     }
-    public static io.tortuga.TortugaProto.Heartbeat parseFrom(
+    public static io.tortuga.TortugaProto.HeartbeatReq parseFrom(
         byte[] data,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws com.google.protobuf.InvalidProtocolBufferException {
       return PARSER.parseFrom(data, extensionRegistry);
     }
-    public static io.tortuga.TortugaProto.Heartbeat parseFrom(java.io.InputStream input)
+    public static io.tortuga.TortugaProto.HeartbeatReq parseFrom(java.io.InputStream input)
         throws java.io.IOException {
       return com.google.protobuf.GeneratedMessageV3
           .parseWithIOException(PARSER, input);
     }
-    public static io.tortuga.TortugaProto.Heartbeat parseFrom(
+    public static io.tortuga.TortugaProto.HeartbeatReq parseFrom(
         java.io.InputStream input,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws java.io.IOException {
       return com.google.protobuf.GeneratedMessageV3
           .parseWithIOException(PARSER, input, extensionRegistry);
     }
-    public static io.tortuga.TortugaProto.Heartbeat parseDelimitedFrom(java.io.InputStream input)
+    public static io.tortuga.TortugaProto.HeartbeatReq parseDelimitedFrom(java.io.InputStream input)
         throws java.io.IOException {
       return com.google.protobuf.GeneratedMessageV3
           .parseDelimitedWithIOException(PARSER, input);
     }
-    public static io.tortuga.TortugaProto.Heartbeat parseDelimitedFrom(
+    public static io.tortuga.TortugaProto.HeartbeatReq parseDelimitedFrom(
         java.io.InputStream input,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws java.io.IOException {
       return com.google.protobuf.GeneratedMessageV3
           .parseDelimitedWithIOException(PARSER, input, extensionRegistry);
     }
-    public static io.tortuga.TortugaProto.Heartbeat parseFrom(
+    public static io.tortuga.TortugaProto.HeartbeatReq parseFrom(
         com.google.protobuf.CodedInputStream input)
         throws java.io.IOException {
       return com.google.protobuf.GeneratedMessageV3
           .parseWithIOException(PARSER, input);
     }
-    public static io.tortuga.TortugaProto.Heartbeat parseFrom(
+    public static io.tortuga.TortugaProto.HeartbeatReq parseFrom(
         com.google.protobuf.CodedInputStream input,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws java.io.IOException {
@@ -1315,7 +2044,7 @@ public final class TortugaProto {
     public static Builder newBuilder() {
       return DEFAULT_INSTANCE.toBuilder();
     }
-    public static Builder newBuilder(io.tortuga.TortugaProto.Heartbeat prototype) {
+    public static Builder newBuilder(io.tortuga.TortugaProto.HeartbeatReq prototype) {
       return DEFAULT_INSTANCE.toBuilder().mergeFrom(prototype);
     }
     public Builder toBuilder() {
@@ -1330,25 +2059,25 @@ public final class TortugaProto {
       return builder;
     }
     /**
-     * Protobuf type {@code tortuga.Heartbeat}
+     * Protobuf type {@code tortuga.HeartbeatReq}
      */
     public static final class Builder extends
         com.google.protobuf.GeneratedMessageV3.Builder<Builder> implements
-        // @@protoc_insertion_point(builder_implements:tortuga.Heartbeat)
-        io.tortuga.TortugaProto.HeartbeatOrBuilder {
+        // @@protoc_insertion_point(builder_implements:tortuga.HeartbeatReq)
+        io.tortuga.TortugaProto.HeartbeatReqOrBuilder {
       public static final com.google.protobuf.Descriptors.Descriptor
           getDescriptor() {
-        return io.tortuga.TortugaProto.internal_static_tortuga_Heartbeat_descriptor;
+        return io.tortuga.TortugaProto.internal_static_tortuga_HeartbeatReq_descriptor;
       }
 
       protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
           internalGetFieldAccessorTable() {
-        return io.tortuga.TortugaProto.internal_static_tortuga_Heartbeat_fieldAccessorTable
+        return io.tortuga.TortugaProto.internal_static_tortuga_HeartbeatReq_fieldAccessorTable
             .ensureFieldAccessorsInitialized(
-                io.tortuga.TortugaProto.Heartbeat.class, io.tortuga.TortugaProto.Heartbeat.Builder.class);
+                io.tortuga.TortugaProto.HeartbeatReq.class, io.tortuga.TortugaProto.HeartbeatReq.Builder.class);
       }
 
-      // Construct using io.tortuga.TortugaProto.Heartbeat.newBuilder()
+      // Construct using io.tortuga.TortugaProto.HeartbeatReq.newBuilder()
       private Builder() {
         maybeForceBuilderInitialization();
       }
@@ -1361,53 +2090,49 @@ public final class TortugaProto {
       private void maybeForceBuilderInitialization() {
         if (com.google.protobuf.GeneratedMessageV3
                 .alwaysUseFieldBuilders) {
+          getWorkerBeatsFieldBuilder();
         }
       }
       public Builder clear() {
         super.clear();
-        if (workerBuilder_ == null) {
-          worker_ = null;
+        if (workerBeatsBuilder_ == null) {
+          workerBeats_ = java.util.Collections.emptyList();
+          bitField0_ = (bitField0_ & ~0x00000001);
         } else {
-          worker_ = null;
-          workerBuilder_ = null;
+          workerBeatsBuilder_.clear();
         }
-        currentTaskHandles_ = java.util.Collections.emptyList();
-        bitField0_ = (bitField0_ & ~0x00000002);
         return this;
       }
 
       public com.google.protobuf.Descriptors.Descriptor
           getDescriptorForType() {
-        return io.tortuga.TortugaProto.internal_static_tortuga_Heartbeat_descriptor;
+        return io.tortuga.TortugaProto.internal_static_tortuga_HeartbeatReq_descriptor;
       }
 
-      public io.tortuga.TortugaProto.Heartbeat getDefaultInstanceForType() {
-        return io.tortuga.TortugaProto.Heartbeat.getDefaultInstance();
+      public io.tortuga.TortugaProto.HeartbeatReq getDefaultInstanceForType() {
+        return io.tortuga.TortugaProto.HeartbeatReq.getDefaultInstance();
       }
 
-      public io.tortuga.TortugaProto.Heartbeat build() {
-        io.tortuga.TortugaProto.Heartbeat result = buildPartial();
+      public io.tortuga.TortugaProto.HeartbeatReq build() {
+        io.tortuga.TortugaProto.HeartbeatReq result = buildPartial();
         if (!result.isInitialized()) {
           throw newUninitializedMessageException(result);
         }
         return result;
       }
 
-      public io.tortuga.TortugaProto.Heartbeat buildPartial() {
-        io.tortuga.TortugaProto.Heartbeat result = new io.tortuga.TortugaProto.Heartbeat(this);
+      public io.tortuga.TortugaProto.HeartbeatReq buildPartial() {
+        io.tortuga.TortugaProto.HeartbeatReq result = new io.tortuga.TortugaProto.HeartbeatReq(this);
         int from_bitField0_ = bitField0_;
-        int to_bitField0_ = 0;
-        if (workerBuilder_ == null) {
-          result.worker_ = worker_;
+        if (workerBeatsBuilder_ == null) {
+          if (((bitField0_ & 0x00000001) == 0x00000001)) {
+            workerBeats_ = java.util.Collections.unmodifiableList(workerBeats_);
+            bitField0_ = (bitField0_ & ~0x00000001);
+          }
+          result.workerBeats_ = workerBeats_;
         } else {
-          result.worker_ = workerBuilder_.build();
+          result.workerBeats_ = workerBeatsBuilder_.build();
         }
-        if (((bitField0_ & 0x00000002) == 0x00000002)) {
-          currentTaskHandles_ = java.util.Collections.unmodifiableList(currentTaskHandles_);
-          bitField0_ = (bitField0_ & ~0x00000002);
-        }
-        result.currentTaskHandles_ = currentTaskHandles_;
-        result.bitField0_ = to_bitField0_;
         onBuilt();
         return result;
       }
@@ -1439,28 +2164,41 @@ public final class TortugaProto {
         return (Builder) super.addRepeatedField(field, value);
       }
       public Builder mergeFrom(com.google.protobuf.Message other) {
-        if (other instanceof io.tortuga.TortugaProto.Heartbeat) {
-          return mergeFrom((io.tortuga.TortugaProto.Heartbeat)other);
+        if (other instanceof io.tortuga.TortugaProto.HeartbeatReq) {
+          return mergeFrom((io.tortuga.TortugaProto.HeartbeatReq)other);
         } else {
           super.mergeFrom(other);
           return this;
         }
       }
 
-      public Builder mergeFrom(io.tortuga.TortugaProto.Heartbeat other) {
-        if (other == io.tortuga.TortugaProto.Heartbeat.getDefaultInstance()) return this;
-        if (other.hasWorker()) {
-          mergeWorker(other.getWorker());
-        }
-        if (!other.currentTaskHandles_.isEmpty()) {
-          if (currentTaskHandles_.isEmpty()) {
-            currentTaskHandles_ = other.currentTaskHandles_;
-            bitField0_ = (bitField0_ & ~0x00000002);
-          } else {
-            ensureCurrentTaskHandlesIsMutable();
-            currentTaskHandles_.addAll(other.currentTaskHandles_);
+      public Builder mergeFrom(io.tortuga.TortugaProto.HeartbeatReq other) {
+        if (other == io.tortuga.TortugaProto.HeartbeatReq.getDefaultInstance()) return this;
+        if (workerBeatsBuilder_ == null) {
+          if (!other.workerBeats_.isEmpty()) {
+            if (workerBeats_.isEmpty()) {
+              workerBeats_ = other.workerBeats_;
+              bitField0_ = (bitField0_ & ~0x00000001);
+            } else {
+              ensureWorkerBeatsIsMutable();
+              workerBeats_.addAll(other.workerBeats_);
+            }
+            onChanged();
           }
-          onChanged();
+        } else {
+          if (!other.workerBeats_.isEmpty()) {
+            if (workerBeatsBuilder_.isEmpty()) {
+              workerBeatsBuilder_.dispose();
+              workerBeatsBuilder_ = null;
+              workerBeats_ = other.workerBeats_;
+              bitField0_ = (bitField0_ & ~0x00000001);
+              workerBeatsBuilder_ = 
+                com.google.protobuf.GeneratedMessageV3.alwaysUseFieldBuilders ?
+                   getWorkerBeatsFieldBuilder() : null;
+            } else {
+              workerBeatsBuilder_.addAllMessages(other.workerBeats_);
+            }
+          }
         }
         this.mergeUnknownFields(other.unknownFields);
         onChanged();
@@ -1475,11 +2213,11 @@ public final class TortugaProto {
           com.google.protobuf.CodedInputStream input,
           com.google.protobuf.ExtensionRegistryLite extensionRegistry)
           throws java.io.IOException {
-        io.tortuga.TortugaProto.Heartbeat parsedMessage = null;
+        io.tortuga.TortugaProto.HeartbeatReq parsedMessage = null;
         try {
           parsedMessage = PARSER.parsePartialFrom(input, extensionRegistry);
         } catch (com.google.protobuf.InvalidProtocolBufferException e) {
-          parsedMessage = (io.tortuga.TortugaProto.Heartbeat) e.getUnfinishedMessage();
+          parsedMessage = (io.tortuga.TortugaProto.HeartbeatReq) e.getUnfinishedMessage();
           throw e.unwrapIOException();
         } finally {
           if (parsedMessage != null) {
@@ -1490,215 +2228,244 @@ public final class TortugaProto {
       }
       private int bitField0_;
 
-      private io.tortuga.TortugaProto.Worker worker_ = null;
-      private com.google.protobuf.SingleFieldBuilderV3<
-          io.tortuga.TortugaProto.Worker, io.tortuga.TortugaProto.Worker.Builder, io.tortuga.TortugaProto.WorkerOrBuilder> workerBuilder_;
-      /**
-       * <code>.tortuga.Worker worker = 1;</code>
-       */
-      public boolean hasWorker() {
-        return workerBuilder_ != null || worker_ != null;
+      private java.util.List<io.tortuga.TortugaProto.HeartbeatReq.WorkerBeat> workerBeats_ =
+        java.util.Collections.emptyList();
+      private void ensureWorkerBeatsIsMutable() {
+        if (!((bitField0_ & 0x00000001) == 0x00000001)) {
+          workerBeats_ = new java.util.ArrayList<io.tortuga.TortugaProto.HeartbeatReq.WorkerBeat>(workerBeats_);
+          bitField0_ |= 0x00000001;
+         }
       }
+
+      private com.google.protobuf.RepeatedFieldBuilderV3<
+          io.tortuga.TortugaProto.HeartbeatReq.WorkerBeat, io.tortuga.TortugaProto.HeartbeatReq.WorkerBeat.Builder, io.tortuga.TortugaProto.HeartbeatReq.WorkerBeatOrBuilder> workerBeatsBuilder_;
+
       /**
-       * <code>.tortuga.Worker worker = 1;</code>
+       * <code>repeated .tortuga.HeartbeatReq.WorkerBeat worker_beats = 1;</code>
        */
-      public io.tortuga.TortugaProto.Worker getWorker() {
-        if (workerBuilder_ == null) {
-          return worker_ == null ? io.tortuga.TortugaProto.Worker.getDefaultInstance() : worker_;
+      public java.util.List<io.tortuga.TortugaProto.HeartbeatReq.WorkerBeat> getWorkerBeatsList() {
+        if (workerBeatsBuilder_ == null) {
+          return java.util.Collections.unmodifiableList(workerBeats_);
         } else {
-          return workerBuilder_.getMessage();
+          return workerBeatsBuilder_.getMessageList();
         }
       }
       /**
-       * <code>.tortuga.Worker worker = 1;</code>
+       * <code>repeated .tortuga.HeartbeatReq.WorkerBeat worker_beats = 1;</code>
        */
-      public Builder setWorker(io.tortuga.TortugaProto.Worker value) {
-        if (workerBuilder_ == null) {
+      public int getWorkerBeatsCount() {
+        if (workerBeatsBuilder_ == null) {
+          return workerBeats_.size();
+        } else {
+          return workerBeatsBuilder_.getCount();
+        }
+      }
+      /**
+       * <code>repeated .tortuga.HeartbeatReq.WorkerBeat worker_beats = 1;</code>
+       */
+      public io.tortuga.TortugaProto.HeartbeatReq.WorkerBeat getWorkerBeats(int index) {
+        if (workerBeatsBuilder_ == null) {
+          return workerBeats_.get(index);
+        } else {
+          return workerBeatsBuilder_.getMessage(index);
+        }
+      }
+      /**
+       * <code>repeated .tortuga.HeartbeatReq.WorkerBeat worker_beats = 1;</code>
+       */
+      public Builder setWorkerBeats(
+          int index, io.tortuga.TortugaProto.HeartbeatReq.WorkerBeat value) {
+        if (workerBeatsBuilder_ == null) {
           if (value == null) {
             throw new NullPointerException();
           }
-          worker_ = value;
+          ensureWorkerBeatsIsMutable();
+          workerBeats_.set(index, value);
           onChanged();
         } else {
-          workerBuilder_.setMessage(value);
+          workerBeatsBuilder_.setMessage(index, value);
         }
-
         return this;
       }
       /**
-       * <code>.tortuga.Worker worker = 1;</code>
+       * <code>repeated .tortuga.HeartbeatReq.WorkerBeat worker_beats = 1;</code>
        */
-      public Builder setWorker(
-          io.tortuga.TortugaProto.Worker.Builder builderForValue) {
-        if (workerBuilder_ == null) {
-          worker_ = builderForValue.build();
+      public Builder setWorkerBeats(
+          int index, io.tortuga.TortugaProto.HeartbeatReq.WorkerBeat.Builder builderForValue) {
+        if (workerBeatsBuilder_ == null) {
+          ensureWorkerBeatsIsMutable();
+          workerBeats_.set(index, builderForValue.build());
           onChanged();
         } else {
-          workerBuilder_.setMessage(builderForValue.build());
+          workerBeatsBuilder_.setMessage(index, builderForValue.build());
         }
-
         return this;
       }
       /**
-       * <code>.tortuga.Worker worker = 1;</code>
+       * <code>repeated .tortuga.HeartbeatReq.WorkerBeat worker_beats = 1;</code>
        */
-      public Builder mergeWorker(io.tortuga.TortugaProto.Worker value) {
-        if (workerBuilder_ == null) {
-          if (worker_ != null) {
-            worker_ =
-              io.tortuga.TortugaProto.Worker.newBuilder(worker_).mergeFrom(value).buildPartial();
-          } else {
-            worker_ = value;
+      public Builder addWorkerBeats(io.tortuga.TortugaProto.HeartbeatReq.WorkerBeat value) {
+        if (workerBeatsBuilder_ == null) {
+          if (value == null) {
+            throw new NullPointerException();
           }
+          ensureWorkerBeatsIsMutable();
+          workerBeats_.add(value);
           onChanged();
         } else {
-          workerBuilder_.mergeFrom(value);
+          workerBeatsBuilder_.addMessage(value);
         }
-
         return this;
       }
       /**
-       * <code>.tortuga.Worker worker = 1;</code>
+       * <code>repeated .tortuga.HeartbeatReq.WorkerBeat worker_beats = 1;</code>
        */
-      public Builder clearWorker() {
-        if (workerBuilder_ == null) {
-          worker_ = null;
+      public Builder addWorkerBeats(
+          int index, io.tortuga.TortugaProto.HeartbeatReq.WorkerBeat value) {
+        if (workerBeatsBuilder_ == null) {
+          if (value == null) {
+            throw new NullPointerException();
+          }
+          ensureWorkerBeatsIsMutable();
+          workerBeats_.add(index, value);
           onChanged();
         } else {
-          worker_ = null;
-          workerBuilder_ = null;
+          workerBeatsBuilder_.addMessage(index, value);
         }
-
         return this;
       }
       /**
-       * <code>.tortuga.Worker worker = 1;</code>
+       * <code>repeated .tortuga.HeartbeatReq.WorkerBeat worker_beats = 1;</code>
        */
-      public io.tortuga.TortugaProto.Worker.Builder getWorkerBuilder() {
-        
-        onChanged();
-        return getWorkerFieldBuilder().getBuilder();
+      public Builder addWorkerBeats(
+          io.tortuga.TortugaProto.HeartbeatReq.WorkerBeat.Builder builderForValue) {
+        if (workerBeatsBuilder_ == null) {
+          ensureWorkerBeatsIsMutable();
+          workerBeats_.add(builderForValue.build());
+          onChanged();
+        } else {
+          workerBeatsBuilder_.addMessage(builderForValue.build());
+        }
+        return this;
       }
       /**
-       * <code>.tortuga.Worker worker = 1;</code>
+       * <code>repeated .tortuga.HeartbeatReq.WorkerBeat worker_beats = 1;</code>
        */
-      public io.tortuga.TortugaProto.WorkerOrBuilder getWorkerOrBuilder() {
-        if (workerBuilder_ != null) {
-          return workerBuilder_.getMessageOrBuilder();
+      public Builder addWorkerBeats(
+          int index, io.tortuga.TortugaProto.HeartbeatReq.WorkerBeat.Builder builderForValue) {
+        if (workerBeatsBuilder_ == null) {
+          ensureWorkerBeatsIsMutable();
+          workerBeats_.add(index, builderForValue.build());
+          onChanged();
         } else {
-          return worker_ == null ?
-              io.tortuga.TortugaProto.Worker.getDefaultInstance() : worker_;
+          workerBeatsBuilder_.addMessage(index, builderForValue.build());
+        }
+        return this;
+      }
+      /**
+       * <code>repeated .tortuga.HeartbeatReq.WorkerBeat worker_beats = 1;</code>
+       */
+      public Builder addAllWorkerBeats(
+          java.lang.Iterable<? extends io.tortuga.TortugaProto.HeartbeatReq.WorkerBeat> values) {
+        if (workerBeatsBuilder_ == null) {
+          ensureWorkerBeatsIsMutable();
+          com.google.protobuf.AbstractMessageLite.Builder.addAll(
+              values, workerBeats_);
+          onChanged();
+        } else {
+          workerBeatsBuilder_.addAllMessages(values);
+        }
+        return this;
+      }
+      /**
+       * <code>repeated .tortuga.HeartbeatReq.WorkerBeat worker_beats = 1;</code>
+       */
+      public Builder clearWorkerBeats() {
+        if (workerBeatsBuilder_ == null) {
+          workerBeats_ = java.util.Collections.emptyList();
+          bitField0_ = (bitField0_ & ~0x00000001);
+          onChanged();
+        } else {
+          workerBeatsBuilder_.clear();
+        }
+        return this;
+      }
+      /**
+       * <code>repeated .tortuga.HeartbeatReq.WorkerBeat worker_beats = 1;</code>
+       */
+      public Builder removeWorkerBeats(int index) {
+        if (workerBeatsBuilder_ == null) {
+          ensureWorkerBeatsIsMutable();
+          workerBeats_.remove(index);
+          onChanged();
+        } else {
+          workerBeatsBuilder_.remove(index);
+        }
+        return this;
+      }
+      /**
+       * <code>repeated .tortuga.HeartbeatReq.WorkerBeat worker_beats = 1;</code>
+       */
+      public io.tortuga.TortugaProto.HeartbeatReq.WorkerBeat.Builder getWorkerBeatsBuilder(
+          int index) {
+        return getWorkerBeatsFieldBuilder().getBuilder(index);
+      }
+      /**
+       * <code>repeated .tortuga.HeartbeatReq.WorkerBeat worker_beats = 1;</code>
+       */
+      public io.tortuga.TortugaProto.HeartbeatReq.WorkerBeatOrBuilder getWorkerBeatsOrBuilder(
+          int index) {
+        if (workerBeatsBuilder_ == null) {
+          return workerBeats_.get(index);  } else {
+          return workerBeatsBuilder_.getMessageOrBuilder(index);
         }
       }
       /**
-       * <code>.tortuga.Worker worker = 1;</code>
+       * <code>repeated .tortuga.HeartbeatReq.WorkerBeat worker_beats = 1;</code>
        */
-      private com.google.protobuf.SingleFieldBuilderV3<
-          io.tortuga.TortugaProto.Worker, io.tortuga.TortugaProto.Worker.Builder, io.tortuga.TortugaProto.WorkerOrBuilder> 
-          getWorkerFieldBuilder() {
-        if (workerBuilder_ == null) {
-          workerBuilder_ = new com.google.protobuf.SingleFieldBuilderV3<
-              io.tortuga.TortugaProto.Worker, io.tortuga.TortugaProto.Worker.Builder, io.tortuga.TortugaProto.WorkerOrBuilder>(
-                  getWorker(),
+      public java.util.List<? extends io.tortuga.TortugaProto.HeartbeatReq.WorkerBeatOrBuilder> 
+           getWorkerBeatsOrBuilderList() {
+        if (workerBeatsBuilder_ != null) {
+          return workerBeatsBuilder_.getMessageOrBuilderList();
+        } else {
+          return java.util.Collections.unmodifiableList(workerBeats_);
+        }
+      }
+      /**
+       * <code>repeated .tortuga.HeartbeatReq.WorkerBeat worker_beats = 1;</code>
+       */
+      public io.tortuga.TortugaProto.HeartbeatReq.WorkerBeat.Builder addWorkerBeatsBuilder() {
+        return getWorkerBeatsFieldBuilder().addBuilder(
+            io.tortuga.TortugaProto.HeartbeatReq.WorkerBeat.getDefaultInstance());
+      }
+      /**
+       * <code>repeated .tortuga.HeartbeatReq.WorkerBeat worker_beats = 1;</code>
+       */
+      public io.tortuga.TortugaProto.HeartbeatReq.WorkerBeat.Builder addWorkerBeatsBuilder(
+          int index) {
+        return getWorkerBeatsFieldBuilder().addBuilder(
+            index, io.tortuga.TortugaProto.HeartbeatReq.WorkerBeat.getDefaultInstance());
+      }
+      /**
+       * <code>repeated .tortuga.HeartbeatReq.WorkerBeat worker_beats = 1;</code>
+       */
+      public java.util.List<io.tortuga.TortugaProto.HeartbeatReq.WorkerBeat.Builder> 
+           getWorkerBeatsBuilderList() {
+        return getWorkerBeatsFieldBuilder().getBuilderList();
+      }
+      private com.google.protobuf.RepeatedFieldBuilderV3<
+          io.tortuga.TortugaProto.HeartbeatReq.WorkerBeat, io.tortuga.TortugaProto.HeartbeatReq.WorkerBeat.Builder, io.tortuga.TortugaProto.HeartbeatReq.WorkerBeatOrBuilder> 
+          getWorkerBeatsFieldBuilder() {
+        if (workerBeatsBuilder_ == null) {
+          workerBeatsBuilder_ = new com.google.protobuf.RepeatedFieldBuilderV3<
+              io.tortuga.TortugaProto.HeartbeatReq.WorkerBeat, io.tortuga.TortugaProto.HeartbeatReq.WorkerBeat.Builder, io.tortuga.TortugaProto.HeartbeatReq.WorkerBeatOrBuilder>(
+                  workerBeats_,
+                  ((bitField0_ & 0x00000001) == 0x00000001),
                   getParentForChildren(),
                   isClean());
-          worker_ = null;
+          workerBeats_ = null;
         }
-        return workerBuilder_;
-      }
-
-      private java.util.List<java.lang.Long> currentTaskHandles_ = java.util.Collections.emptyList();
-      private void ensureCurrentTaskHandlesIsMutable() {
-        if (!((bitField0_ & 0x00000002) == 0x00000002)) {
-          currentTaskHandles_ = new java.util.ArrayList<java.lang.Long>(currentTaskHandles_);
-          bitField0_ |= 0x00000002;
-         }
-      }
-      /**
-       * <pre>
-       * They must be sorted!
-       * </pre>
-       *
-       * <code>repeated int64 current_task_handles = 2;</code>
-       */
-      public java.util.List<java.lang.Long>
-          getCurrentTaskHandlesList() {
-        return java.util.Collections.unmodifiableList(currentTaskHandles_);
-      }
-      /**
-       * <pre>
-       * They must be sorted!
-       * </pre>
-       *
-       * <code>repeated int64 current_task_handles = 2;</code>
-       */
-      public int getCurrentTaskHandlesCount() {
-        return currentTaskHandles_.size();
-      }
-      /**
-       * <pre>
-       * They must be sorted!
-       * </pre>
-       *
-       * <code>repeated int64 current_task_handles = 2;</code>
-       */
-      public long getCurrentTaskHandles(int index) {
-        return currentTaskHandles_.get(index);
-      }
-      /**
-       * <pre>
-       * They must be sorted!
-       * </pre>
-       *
-       * <code>repeated int64 current_task_handles = 2;</code>
-       */
-      public Builder setCurrentTaskHandles(
-          int index, long value) {
-        ensureCurrentTaskHandlesIsMutable();
-        currentTaskHandles_.set(index, value);
-        onChanged();
-        return this;
-      }
-      /**
-       * <pre>
-       * They must be sorted!
-       * </pre>
-       *
-       * <code>repeated int64 current_task_handles = 2;</code>
-       */
-      public Builder addCurrentTaskHandles(long value) {
-        ensureCurrentTaskHandlesIsMutable();
-        currentTaskHandles_.add(value);
-        onChanged();
-        return this;
-      }
-      /**
-       * <pre>
-       * They must be sorted!
-       * </pre>
-       *
-       * <code>repeated int64 current_task_handles = 2;</code>
-       */
-      public Builder addAllCurrentTaskHandles(
-          java.lang.Iterable<? extends java.lang.Long> values) {
-        ensureCurrentTaskHandlesIsMutable();
-        com.google.protobuf.AbstractMessageLite.Builder.addAll(
-            values, currentTaskHandles_);
-        onChanged();
-        return this;
-      }
-      /**
-       * <pre>
-       * They must be sorted!
-       * </pre>
-       *
-       * <code>repeated int64 current_task_handles = 2;</code>
-       */
-      public Builder clearCurrentTaskHandles() {
-        currentTaskHandles_ = java.util.Collections.emptyList();
-        bitField0_ = (bitField0_ & ~0x00000002);
-        onChanged();
-        return this;
+        return workerBeatsBuilder_;
       }
       public final Builder setUnknownFields(
           final com.google.protobuf.UnknownFieldSet unknownFields) {
@@ -1711,39 +2478,39 @@ public final class TortugaProto {
       }
 
 
-      // @@protoc_insertion_point(builder_scope:tortuga.Heartbeat)
+      // @@protoc_insertion_point(builder_scope:tortuga.HeartbeatReq)
     }
 
-    // @@protoc_insertion_point(class_scope:tortuga.Heartbeat)
-    private static final io.tortuga.TortugaProto.Heartbeat DEFAULT_INSTANCE;
+    // @@protoc_insertion_point(class_scope:tortuga.HeartbeatReq)
+    private static final io.tortuga.TortugaProto.HeartbeatReq DEFAULT_INSTANCE;
     static {
-      DEFAULT_INSTANCE = new io.tortuga.TortugaProto.Heartbeat();
+      DEFAULT_INSTANCE = new io.tortuga.TortugaProto.HeartbeatReq();
     }
 
-    public static io.tortuga.TortugaProto.Heartbeat getDefaultInstance() {
+    public static io.tortuga.TortugaProto.HeartbeatReq getDefaultInstance() {
       return DEFAULT_INSTANCE;
     }
 
-    private static final com.google.protobuf.Parser<Heartbeat>
-        PARSER = new com.google.protobuf.AbstractParser<Heartbeat>() {
-      public Heartbeat parsePartialFrom(
+    private static final com.google.protobuf.Parser<HeartbeatReq>
+        PARSER = new com.google.protobuf.AbstractParser<HeartbeatReq>() {
+      public HeartbeatReq parsePartialFrom(
           com.google.protobuf.CodedInputStream input,
           com.google.protobuf.ExtensionRegistryLite extensionRegistry)
           throws com.google.protobuf.InvalidProtocolBufferException {
-        return new Heartbeat(input, extensionRegistry);
+        return new HeartbeatReq(input, extensionRegistry);
       }
     };
 
-    public static com.google.protobuf.Parser<Heartbeat> parser() {
+    public static com.google.protobuf.Parser<HeartbeatReq> parser() {
       return PARSER;
     }
 
     @java.lang.Override
-    public com.google.protobuf.Parser<Heartbeat> getParserForType() {
+    public com.google.protobuf.Parser<HeartbeatReq> getParserForType() {
       return PARSER;
     }
 
-    public io.tortuga.TortugaProto.Heartbeat getDefaultInstanceForType() {
+    public io.tortuga.TortugaProto.HeartbeatReq getDefaultInstanceForType() {
       return DEFAULT_INSTANCE;
     }
 
@@ -14371,10 +15138,15 @@ public final class TortugaProto {
     com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
       internal_static_tortuga_Worker_fieldAccessorTable;
   private static final com.google.protobuf.Descriptors.Descriptor
-    internal_static_tortuga_Heartbeat_descriptor;
+    internal_static_tortuga_HeartbeatReq_descriptor;
   private static final 
     com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
-      internal_static_tortuga_Heartbeat_fieldAccessorTable;
+      internal_static_tortuga_HeartbeatReq_fieldAccessorTable;
+  private static final com.google.protobuf.Descriptors.Descriptor
+    internal_static_tortuga_HeartbeatReq_WorkerBeat_descriptor;
+  private static final 
+    com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
+      internal_static_tortuga_HeartbeatReq_WorkerBeat_fieldAccessorTable;
   private static final com.google.protobuf.Descriptors.Descriptor
     internal_static_tortuga_TaskReq_descriptor;
   private static final 
@@ -14450,51 +15222,53 @@ public final class TortugaProto {
       "\032\037google/protobuf/timestamp.proto\032\036googl" +
       "e/protobuf/wrappers.proto\032\027google/rpc/st" +
       "atus.proto\"?\n\006Worker\022\021\n\tworker_id\030\001 \001(\t\022" +
-      "\014\n\004uuid\030\002 \001(\t\022\024\n\014capabilities\030\003 \003(\t\"J\n\tH" +
-      "eartbeat\022\037\n\006worker\030\001 \001(\0132\017.tortuga.Worke" +
-      "r\022\034\n\024current_task_handles\030\002 \003(\003\"*\n\007TaskR" +
-      "eq\022\037\n\006worker\030\001 \001(\0132\017.tortuga.Worker\"\325\001\n\010" +
-      "TaskResp\022\n\n\002id\030\001 \001(\t\022\014\n\004type\030\002 \001(\t\022\"\n\004da" +
-      "ta\030\003 \001(\0132\024.google.protobuf.Any\022\016\n\006handle" +
-      "\030\004 \001(\t\022\014\n\004none\030\005 \001(\010\0221\n\tretry_ctx\030\006 \001(\0132" +
-      "\036.tortuga.TaskResp.RetryContext\032:\n\014Retry" +
-      "Context\022\017\n\007retries\030\001 \001(\005\022\031\n\021progress_met" +
-      "adata\030\002 \001(\t\"\340\001\n\004Task\022\n\n\002id\030\001 \001(\t\022\014\n\004type" +
-      "\030\002 \001(\t\022\"\n\004data\030\003 \001(\0132\024.google.protobuf.A" +
-      "ny\022-\n\010priority\030\004 \001(\0132\033.google.protobuf.I" +
-      "nt32Value\0220\n\013max_retries\030\005 \001(\0132\033.google." +
-      "protobuf.Int32Value\022(\n\005delay\030\006 \001(\0132\031.goo" +
-      "gle.protobuf.Duration\022\017\n\007modules\030\007 \003(\t\"\273" +
-      "\003\n\014TaskProgress\022\016\n\006handle\030\001 \001(\t\022\n\n\002id\030\002 " +
-      "\001(\t\022\014\n\004type\030\003 \001(\t\022\023\n\013max_retries\030\004 \001(\005\022\017" +
-      "\n\007retries\030\005 \001(\005\022\020\n\010priority\030\006 \001(\005\022\021\n\twor" +
-      "ked_on\030\007 \001(\010\022\014\n\004done\030\010 \001(\010\022+\n\007created\030\t " +
-      "\001(\0132\032.google.protobuf.Timestamp\0220\n\014start" +
-      "ed_time\030\n \001(\0132\032.google.protobuf.Timestam" +
-      "p\022-\n\tdone_time\030\013 \001(\0132\032.google.protobuf.T" +
-      "imestamp\022\"\n\006status\030\014 \001(\0132\022.google.rpc.St" +
-      "atus\022\020\n\010progress\030\r \001(\002\022\030\n\020progress_messa" +
-      "ge\030\016 \001(\t\022\031\n\021progress_metadata\030\022 \001(\t\022\014\n\004l" +
-      "ogs\030\017 \001(\t\022\021\n\tworker_id\030\020 \001(\t\022\016\n\006output\030\021" +
-      " \001(\t\"(\n\tCreateReq\022\033\n\004task\030\001 \001(\0132\r.tortug" +
-      "a.Task\"-\n\nCreateResp\022\016\n\006handle\030\001 \001(\t\022\017\n\007" +
-      "created\030\002 \001(\010\"\205\001\n\017CompleteTaskReq\022\037\n\006wor" +
-      "ker\030\001 \001(\0132\017.tortuga.Worker\022\016\n\006handle\030\002 \001" +
-      "(\t\022\014\n\004code\030\003 \001(\005\022\025\n\rerror_message\030\004 \001(\t\022" +
-      "\014\n\004logs\030\005 \001(\t\022\016\n\006output\030\006 \001(\t\"\344\001\n\021Update" +
-      "ProgressReq\022\037\n\006worker\030\001 \001(\0132\017.tortuga.Wo" +
-      "rker\022\016\n\006handle\030\002 \001(\t\022-\n\010progress\030\003 \001(\0132\033" +
-      ".google.protobuf.FloatValue\0226\n\020progress_" +
-      "message\030\004 \001(\0132\034.google.protobuf.StringVa" +
-      "lue\0227\n\021progress_metadata\030\005 \001(\0132\034.google." +
-      "protobuf.StringValue\"\035\n\013ProgressReq\022\016\n\006h" +
-      "andle\030\001 \001(\t\"B\n\014ProgressResp\022\016\n\006handle\030\001 " +
-      "\001(\t\022\"\n\006status\030\002 \001(\0132\022.google.rpc.Status\"" +
-      "*\n\016TaskIdentifier\022\n\n\002id\030\001 \001(\t\022\014\n\004type\030\002 " +
-      "\001(\t2\257\004\n\007Tortuga\0225\n\nCreateTask\022\022.tortuga." +
-      "CreateReq\032\023.tortuga.CreateResp\0222\n\013Reques" +
-      "tTask\022\020.tortuga.TaskReq\032\021.tortuga.TaskRe" +
-      "sp\0224\n\tHeartbeat\022\017.tortuga.Worker\032\026.googl" +
+      "\014\n\004uuid\030\002 \001(\t\022\024\n\014capabilities\030\003 \003(\t\"\223\001\n\014" +
+      "HeartbeatReq\0226\n\014worker_beats\030\001 \003(\0132 .tor" +
+      "tuga.HeartbeatReq.WorkerBeat\032K\n\nWorkerBe" +
+      "at\022\037\n\006worker\030\001 \001(\0132\017.tortuga.Worker\022\034\n\024c" +
+      "urrent_task_handles\030\002 \003(\003\"*\n\007TaskReq\022\037\n\006" +
+      "worker\030\001 \001(\0132\017.tortuga.Worker\"\325\001\n\010TaskRe" +
+      "sp\022\n\n\002id\030\001 \001(\t\022\014\n\004type\030\002 \001(\t\022\"\n\004data\030\003 \001" +
+      "(\0132\024.google.protobuf.Any\022\016\n\006handle\030\004 \001(\t" +
+      "\022\014\n\004none\030\005 \001(\010\0221\n\tretry_ctx\030\006 \001(\0132\036.tort" +
+      "uga.TaskResp.RetryContext\032:\n\014RetryContex" +
+      "t\022\017\n\007retries\030\001 \001(\005\022\031\n\021progress_metadata\030" +
+      "\002 \001(\t\"\340\001\n\004Task\022\n\n\002id\030\001 \001(\t\022\014\n\004type\030\002 \001(\t" +
+      "\022\"\n\004data\030\003 \001(\0132\024.google.protobuf.Any\022-\n\010" +
+      "priority\030\004 \001(\0132\033.google.protobuf.Int32Va" +
+      "lue\0220\n\013max_retries\030\005 \001(\0132\033.google.protob" +
+      "uf.Int32Value\022(\n\005delay\030\006 \001(\0132\031.google.pr" +
+      "otobuf.Duration\022\017\n\007modules\030\007 \003(\t\"\273\003\n\014Tas" +
+      "kProgress\022\016\n\006handle\030\001 \001(\t\022\n\n\002id\030\002 \001(\t\022\014\n" +
+      "\004type\030\003 \001(\t\022\023\n\013max_retries\030\004 \001(\005\022\017\n\007retr" +
+      "ies\030\005 \001(\005\022\020\n\010priority\030\006 \001(\005\022\021\n\tworked_on" +
+      "\030\007 \001(\010\022\014\n\004done\030\010 \001(\010\022+\n\007created\030\t \001(\0132\032." +
+      "google.protobuf.Timestamp\0220\n\014started_tim" +
+      "e\030\n \001(\0132\032.google.protobuf.Timestamp\022-\n\td" +
+      "one_time\030\013 \001(\0132\032.google.protobuf.Timesta" +
+      "mp\022\"\n\006status\030\014 \001(\0132\022.google.rpc.Status\022\020" +
+      "\n\010progress\030\r \001(\002\022\030\n\020progress_message\030\016 \001" +
+      "(\t\022\031\n\021progress_metadata\030\022 \001(\t\022\014\n\004logs\030\017 " +
+      "\001(\t\022\021\n\tworker_id\030\020 \001(\t\022\016\n\006output\030\021 \001(\t\"(" +
+      "\n\tCreateReq\022\033\n\004task\030\001 \001(\0132\r.tortuga.Task" +
+      "\"-\n\nCreateResp\022\016\n\006handle\030\001 \001(\t\022\017\n\007create" +
+      "d\030\002 \001(\010\"\205\001\n\017CompleteTaskReq\022\037\n\006worker\030\001 " +
+      "\001(\0132\017.tortuga.Worker\022\016\n\006handle\030\002 \001(\t\022\014\n\004" +
+      "code\030\003 \001(\005\022\025\n\rerror_message\030\004 \001(\t\022\014\n\004log" +
+      "s\030\005 \001(\t\022\016\n\006output\030\006 \001(\t\"\344\001\n\021UpdateProgre" +
+      "ssReq\022\037\n\006worker\030\001 \001(\0132\017.tortuga.Worker\022\016" +
+      "\n\006handle\030\002 \001(\t\022-\n\010progress\030\003 \001(\0132\033.googl" +
+      "e.protobuf.FloatValue\0226\n\020progress_messag" +
+      "e\030\004 \001(\0132\034.google.protobuf.StringValue\0227\n" +
+      "\021progress_metadata\030\005 \001(\0132\034.google.protob" +
+      "uf.StringValue\"\035\n\013ProgressReq\022\016\n\006handle\030" +
+      "\001 \001(\t\"B\n\014ProgressResp\022\016\n\006handle\030\001 \001(\t\022\"\n" +
+      "\006status\030\002 \001(\0132\022.google.rpc.Status\"*\n\016Tas" +
+      "kIdentifier\022\n\n\002id\030\001 \001(\t\022\014\n\004type\030\002 \001(\t2\265\004" +
+      "\n\007Tortuga\0225\n\nCreateTask\022\022.tortuga.Create" +
+      "Req\032\023.tortuga.CreateResp\0222\n\013RequestTask\022" +
+      "\020.tortuga.TaskReq\032\021.tortuga.TaskResp\022:\n\t" +
+      "Heartbeat\022\025.tortuga.HeartbeatReq\032\026.googl" +
       "e.protobuf.Empty\022@\n\014CompleteTask\022\030.tortu" +
       "ga.CompleteTaskReq\032\026.google.protobuf.Emp" +
       "ty\022D\n\016UpdateProgress\022\032.tortuga.UpdatePro" +
@@ -14532,11 +15306,17 @@ public final class TortugaProto {
       com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
         internal_static_tortuga_Worker_descriptor,
         new java.lang.String[] { "WorkerId", "Uuid", "Capabilities", });
-    internal_static_tortuga_Heartbeat_descriptor =
+    internal_static_tortuga_HeartbeatReq_descriptor =
       getDescriptor().getMessageTypes().get(1);
-    internal_static_tortuga_Heartbeat_fieldAccessorTable = new
+    internal_static_tortuga_HeartbeatReq_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
-        internal_static_tortuga_Heartbeat_descriptor,
+        internal_static_tortuga_HeartbeatReq_descriptor,
+        new java.lang.String[] { "WorkerBeats", });
+    internal_static_tortuga_HeartbeatReq_WorkerBeat_descriptor =
+      internal_static_tortuga_HeartbeatReq_descriptor.getNestedTypes().get(0);
+    internal_static_tortuga_HeartbeatReq_WorkerBeat_fieldAccessorTable = new
+      com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
+        internal_static_tortuga_HeartbeatReq_WorkerBeat_descriptor,
         new java.lang.String[] { "Worker", "CurrentTaskHandles", });
     internal_static_tortuga_TaskReq_descriptor =
       getDescriptor().getMessageTypes().get(2);

--- a/tortuga/tortuga.cc
+++ b/tortuga/tortuga.cc
@@ -308,7 +308,7 @@ void TortugaHandler::HandleHeartbeat() {
   BatonHandler handler;
 
   grpc::ServerContext ctx;
-  Worker req;
+  HeartbeatReq req;
   grpc::ServerAsyncResponseWriter<google::protobuf::Empty> resp(&ctx);
 
   // start a new RPC and wait.
@@ -324,7 +324,9 @@ void TortugaHandler::HandleHeartbeat() {
   VLOG(3) << "after this req the fibers allocated is: " << rpc_opts_.fibers->fibersAllocated()
           << " pool size: " << rpc_opts_.fibers->fibersPoolSize();
 
-  workers_manager_->Beat(req);
+  for (const auto& worker_beat : req.worker_beats()) {
+    workers_manager_->Beat(worker_beat.worker());
+  }
 
   google::protobuf::Empty reply;
   handler.Reset();

--- a/tortuga/tortuga.grpc.pb.cc
+++ b/tortuga/tortuga.grpc.pb.cc
@@ -69,15 +69,15 @@ Tortuga::Stub::Stub(const std::shared_ptr< ::grpc::ChannelInterface>& channel)
   return ::grpc::internal::ClientAsyncResponseReaderFactory< ::tortuga::TaskResp>::Create(channel_.get(), cq, rpcmethod_RequestTask_, context, request, false);
 }
 
-::grpc::Status Tortuga::Stub::Heartbeat(::grpc::ClientContext* context, const ::tortuga::Worker& request, ::google::protobuf::Empty* response) {
+::grpc::Status Tortuga::Stub::Heartbeat(::grpc::ClientContext* context, const ::tortuga::HeartbeatReq& request, ::google::protobuf::Empty* response) {
   return ::grpc::internal::BlockingUnaryCall(channel_.get(), rpcmethod_Heartbeat_, context, request, response);
 }
 
-::grpc::ClientAsyncResponseReader< ::google::protobuf::Empty>* Tortuga::Stub::AsyncHeartbeatRaw(::grpc::ClientContext* context, const ::tortuga::Worker& request, ::grpc::CompletionQueue* cq) {
+::grpc::ClientAsyncResponseReader< ::google::protobuf::Empty>* Tortuga::Stub::AsyncHeartbeatRaw(::grpc::ClientContext* context, const ::tortuga::HeartbeatReq& request, ::grpc::CompletionQueue* cq) {
   return ::grpc::internal::ClientAsyncResponseReaderFactory< ::google::protobuf::Empty>::Create(channel_.get(), cq, rpcmethod_Heartbeat_, context, request, true);
 }
 
-::grpc::ClientAsyncResponseReader< ::google::protobuf::Empty>* Tortuga::Stub::PrepareAsyncHeartbeatRaw(::grpc::ClientContext* context, const ::tortuga::Worker& request, ::grpc::CompletionQueue* cq) {
+::grpc::ClientAsyncResponseReader< ::google::protobuf::Empty>* Tortuga::Stub::PrepareAsyncHeartbeatRaw(::grpc::ClientContext* context, const ::tortuga::HeartbeatReq& request, ::grpc::CompletionQueue* cq) {
   return ::grpc::internal::ClientAsyncResponseReaderFactory< ::google::protobuf::Empty>::Create(channel_.get(), cq, rpcmethod_Heartbeat_, context, request, false);
 }
 
@@ -167,7 +167,7 @@ Tortuga::Service::Service() {
   AddMethod(new ::grpc::internal::RpcServiceMethod(
       Tortuga_method_names[2],
       ::grpc::internal::RpcMethod::NORMAL_RPC,
-      new ::grpc::internal::RpcMethodHandler< Tortuga::Service, ::tortuga::Worker, ::google::protobuf::Empty>(
+      new ::grpc::internal::RpcMethodHandler< Tortuga::Service, ::tortuga::HeartbeatReq, ::google::protobuf::Empty>(
           std::mem_fn(&Tortuga::Service::Heartbeat), this)));
   AddMethod(new ::grpc::internal::RpcServiceMethod(
       Tortuga_method_names[3],
@@ -218,7 +218,7 @@ Tortuga::Service::~Service() {
   return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
 }
 
-::grpc::Status Tortuga::Service::Heartbeat(::grpc::ServerContext* context, const ::tortuga::Worker* request, ::google::protobuf::Empty* response) {
+::grpc::Status Tortuga::Service::Heartbeat(::grpc::ServerContext* context, const ::tortuga::HeartbeatReq* request, ::google::protobuf::Empty* response) {
   (void) context;
   (void) request;
   (void) response;

--- a/tortuga/tortuga.grpc.pb.h
+++ b/tortuga/tortuga.grpc.pb.h
@@ -49,11 +49,11 @@ class Tortuga final {
     std::unique_ptr< ::grpc::ClientAsyncResponseReaderInterface< ::tortuga::TaskResp>> PrepareAsyncRequestTask(::grpc::ClientContext* context, const ::tortuga::TaskReq& request, ::grpc::CompletionQueue* cq) {
       return std::unique_ptr< ::grpc::ClientAsyncResponseReaderInterface< ::tortuga::TaskResp>>(PrepareAsyncRequestTaskRaw(context, request, cq));
     }
-    virtual ::grpc::Status Heartbeat(::grpc::ClientContext* context, const ::tortuga::Worker& request, ::google::protobuf::Empty* response) = 0;
-    std::unique_ptr< ::grpc::ClientAsyncResponseReaderInterface< ::google::protobuf::Empty>> AsyncHeartbeat(::grpc::ClientContext* context, const ::tortuga::Worker& request, ::grpc::CompletionQueue* cq) {
+    virtual ::grpc::Status Heartbeat(::grpc::ClientContext* context, const ::tortuga::HeartbeatReq& request, ::google::protobuf::Empty* response) = 0;
+    std::unique_ptr< ::grpc::ClientAsyncResponseReaderInterface< ::google::protobuf::Empty>> AsyncHeartbeat(::grpc::ClientContext* context, const ::tortuga::HeartbeatReq& request, ::grpc::CompletionQueue* cq) {
       return std::unique_ptr< ::grpc::ClientAsyncResponseReaderInterface< ::google::protobuf::Empty>>(AsyncHeartbeatRaw(context, request, cq));
     }
-    std::unique_ptr< ::grpc::ClientAsyncResponseReaderInterface< ::google::protobuf::Empty>> PrepareAsyncHeartbeat(::grpc::ClientContext* context, const ::tortuga::Worker& request, ::grpc::CompletionQueue* cq) {
+    std::unique_ptr< ::grpc::ClientAsyncResponseReaderInterface< ::google::protobuf::Empty>> PrepareAsyncHeartbeat(::grpc::ClientContext* context, const ::tortuga::HeartbeatReq& request, ::grpc::CompletionQueue* cq) {
       return std::unique_ptr< ::grpc::ClientAsyncResponseReaderInterface< ::google::protobuf::Empty>>(PrepareAsyncHeartbeatRaw(context, request, cq));
     }
     virtual ::grpc::Status CompleteTask(::grpc::ClientContext* context, const ::tortuga::CompleteTaskReq& request, ::google::protobuf::Empty* response) = 0;
@@ -106,8 +106,8 @@ class Tortuga final {
     virtual ::grpc::ClientAsyncResponseReaderInterface< ::tortuga::CreateResp>* PrepareAsyncCreateTaskRaw(::grpc::ClientContext* context, const ::tortuga::CreateReq& request, ::grpc::CompletionQueue* cq) = 0;
     virtual ::grpc::ClientAsyncResponseReaderInterface< ::tortuga::TaskResp>* AsyncRequestTaskRaw(::grpc::ClientContext* context, const ::tortuga::TaskReq& request, ::grpc::CompletionQueue* cq) = 0;
     virtual ::grpc::ClientAsyncResponseReaderInterface< ::tortuga::TaskResp>* PrepareAsyncRequestTaskRaw(::grpc::ClientContext* context, const ::tortuga::TaskReq& request, ::grpc::CompletionQueue* cq) = 0;
-    virtual ::grpc::ClientAsyncResponseReaderInterface< ::google::protobuf::Empty>* AsyncHeartbeatRaw(::grpc::ClientContext* context, const ::tortuga::Worker& request, ::grpc::CompletionQueue* cq) = 0;
-    virtual ::grpc::ClientAsyncResponseReaderInterface< ::google::protobuf::Empty>* PrepareAsyncHeartbeatRaw(::grpc::ClientContext* context, const ::tortuga::Worker& request, ::grpc::CompletionQueue* cq) = 0;
+    virtual ::grpc::ClientAsyncResponseReaderInterface< ::google::protobuf::Empty>* AsyncHeartbeatRaw(::grpc::ClientContext* context, const ::tortuga::HeartbeatReq& request, ::grpc::CompletionQueue* cq) = 0;
+    virtual ::grpc::ClientAsyncResponseReaderInterface< ::google::protobuf::Empty>* PrepareAsyncHeartbeatRaw(::grpc::ClientContext* context, const ::tortuga::HeartbeatReq& request, ::grpc::CompletionQueue* cq) = 0;
     virtual ::grpc::ClientAsyncResponseReaderInterface< ::google::protobuf::Empty>* AsyncCompleteTaskRaw(::grpc::ClientContext* context, const ::tortuga::CompleteTaskReq& request, ::grpc::CompletionQueue* cq) = 0;
     virtual ::grpc::ClientAsyncResponseReaderInterface< ::google::protobuf::Empty>* PrepareAsyncCompleteTaskRaw(::grpc::ClientContext* context, const ::tortuga::CompleteTaskReq& request, ::grpc::CompletionQueue* cq) = 0;
     virtual ::grpc::ClientAsyncResponseReaderInterface< ::google::protobuf::Empty>* AsyncUpdateProgressRaw(::grpc::ClientContext* context, const ::tortuga::UpdateProgressReq& request, ::grpc::CompletionQueue* cq) = 0;
@@ -138,11 +138,11 @@ class Tortuga final {
     std::unique_ptr< ::grpc::ClientAsyncResponseReader< ::tortuga::TaskResp>> PrepareAsyncRequestTask(::grpc::ClientContext* context, const ::tortuga::TaskReq& request, ::grpc::CompletionQueue* cq) {
       return std::unique_ptr< ::grpc::ClientAsyncResponseReader< ::tortuga::TaskResp>>(PrepareAsyncRequestTaskRaw(context, request, cq));
     }
-    ::grpc::Status Heartbeat(::grpc::ClientContext* context, const ::tortuga::Worker& request, ::google::protobuf::Empty* response) override;
-    std::unique_ptr< ::grpc::ClientAsyncResponseReader< ::google::protobuf::Empty>> AsyncHeartbeat(::grpc::ClientContext* context, const ::tortuga::Worker& request, ::grpc::CompletionQueue* cq) {
+    ::grpc::Status Heartbeat(::grpc::ClientContext* context, const ::tortuga::HeartbeatReq& request, ::google::protobuf::Empty* response) override;
+    std::unique_ptr< ::grpc::ClientAsyncResponseReader< ::google::protobuf::Empty>> AsyncHeartbeat(::grpc::ClientContext* context, const ::tortuga::HeartbeatReq& request, ::grpc::CompletionQueue* cq) {
       return std::unique_ptr< ::grpc::ClientAsyncResponseReader< ::google::protobuf::Empty>>(AsyncHeartbeatRaw(context, request, cq));
     }
-    std::unique_ptr< ::grpc::ClientAsyncResponseReader< ::google::protobuf::Empty>> PrepareAsyncHeartbeat(::grpc::ClientContext* context, const ::tortuga::Worker& request, ::grpc::CompletionQueue* cq) {
+    std::unique_ptr< ::grpc::ClientAsyncResponseReader< ::google::protobuf::Empty>> PrepareAsyncHeartbeat(::grpc::ClientContext* context, const ::tortuga::HeartbeatReq& request, ::grpc::CompletionQueue* cq) {
       return std::unique_ptr< ::grpc::ClientAsyncResponseReader< ::google::protobuf::Empty>>(PrepareAsyncHeartbeatRaw(context, request, cq));
     }
     ::grpc::Status CompleteTask(::grpc::ClientContext* context, const ::tortuga::CompleteTaskReq& request, ::google::protobuf::Empty* response) override;
@@ -194,8 +194,8 @@ class Tortuga final {
     ::grpc::ClientAsyncResponseReader< ::tortuga::CreateResp>* PrepareAsyncCreateTaskRaw(::grpc::ClientContext* context, const ::tortuga::CreateReq& request, ::grpc::CompletionQueue* cq) override;
     ::grpc::ClientAsyncResponseReader< ::tortuga::TaskResp>* AsyncRequestTaskRaw(::grpc::ClientContext* context, const ::tortuga::TaskReq& request, ::grpc::CompletionQueue* cq) override;
     ::grpc::ClientAsyncResponseReader< ::tortuga::TaskResp>* PrepareAsyncRequestTaskRaw(::grpc::ClientContext* context, const ::tortuga::TaskReq& request, ::grpc::CompletionQueue* cq) override;
-    ::grpc::ClientAsyncResponseReader< ::google::protobuf::Empty>* AsyncHeartbeatRaw(::grpc::ClientContext* context, const ::tortuga::Worker& request, ::grpc::CompletionQueue* cq) override;
-    ::grpc::ClientAsyncResponseReader< ::google::protobuf::Empty>* PrepareAsyncHeartbeatRaw(::grpc::ClientContext* context, const ::tortuga::Worker& request, ::grpc::CompletionQueue* cq) override;
+    ::grpc::ClientAsyncResponseReader< ::google::protobuf::Empty>* AsyncHeartbeatRaw(::grpc::ClientContext* context, const ::tortuga::HeartbeatReq& request, ::grpc::CompletionQueue* cq) override;
+    ::grpc::ClientAsyncResponseReader< ::google::protobuf::Empty>* PrepareAsyncHeartbeatRaw(::grpc::ClientContext* context, const ::tortuga::HeartbeatReq& request, ::grpc::CompletionQueue* cq) override;
     ::grpc::ClientAsyncResponseReader< ::google::protobuf::Empty>* AsyncCompleteTaskRaw(::grpc::ClientContext* context, const ::tortuga::CompleteTaskReq& request, ::grpc::CompletionQueue* cq) override;
     ::grpc::ClientAsyncResponseReader< ::google::protobuf::Empty>* PrepareAsyncCompleteTaskRaw(::grpc::ClientContext* context, const ::tortuga::CompleteTaskReq& request, ::grpc::CompletionQueue* cq) override;
     ::grpc::ClientAsyncResponseReader< ::google::protobuf::Empty>* AsyncUpdateProgressRaw(::grpc::ClientContext* context, const ::tortuga::UpdateProgressReq& request, ::grpc::CompletionQueue* cq) override;
@@ -226,7 +226,7 @@ class Tortuga final {
     virtual ~Service();
     virtual ::grpc::Status CreateTask(::grpc::ServerContext* context, const ::tortuga::CreateReq* request, ::tortuga::CreateResp* response);
     virtual ::grpc::Status RequestTask(::grpc::ServerContext* context, const ::tortuga::TaskReq* request, ::tortuga::TaskResp* response);
-    virtual ::grpc::Status Heartbeat(::grpc::ServerContext* context, const ::tortuga::Worker* request, ::google::protobuf::Empty* response);
+    virtual ::grpc::Status Heartbeat(::grpc::ServerContext* context, const ::tortuga::HeartbeatReq* request, ::google::protobuf::Empty* response);
     virtual ::grpc::Status CompleteTask(::grpc::ServerContext* context, const ::tortuga::CompleteTaskReq* request, ::google::protobuf::Empty* response);
     virtual ::grpc::Status UpdateProgress(::grpc::ServerContext* context, const ::tortuga::UpdateProgressReq* request, ::google::protobuf::Empty* response);
     // Finds a task by id and type.
@@ -289,11 +289,11 @@ class Tortuga final {
       BaseClassMustBeDerivedFromService(this);
     }
     // disable synchronous version of this method
-    ::grpc::Status Heartbeat(::grpc::ServerContext* context, const ::tortuga::Worker* request, ::google::protobuf::Empty* response) final override {
+    ::grpc::Status Heartbeat(::grpc::ServerContext* context, const ::tortuga::HeartbeatReq* request, ::google::protobuf::Empty* response) final override {
       abort();
       return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
     }
-    void RequestHeartbeat(::grpc::ServerContext* context, ::tortuga::Worker* request, ::grpc::ServerAsyncResponseWriter< ::google::protobuf::Empty>* response, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
+    void RequestHeartbeat(::grpc::ServerContext* context, ::tortuga::HeartbeatReq* request, ::grpc::ServerAsyncResponseWriter< ::google::protobuf::Empty>* response, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
       ::grpc::Service::RequestAsyncUnary(2, context, request, response, new_call_cq, notification_cq, tag);
     }
   };
@@ -464,7 +464,7 @@ class Tortuga final {
       BaseClassMustBeDerivedFromService(this);
     }
     // disable synchronous version of this method
-    ::grpc::Status Heartbeat(::grpc::ServerContext* context, const ::tortuga::Worker* request, ::google::protobuf::Empty* response) final override {
+    ::grpc::Status Heartbeat(::grpc::ServerContext* context, const ::tortuga::HeartbeatReq* request, ::google::protobuf::Empty* response) final override {
       abort();
       return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
     }
@@ -618,18 +618,18 @@ class Tortuga final {
    public:
     WithStreamedUnaryMethod_Heartbeat() {
       ::grpc::Service::MarkMethodStreamed(2,
-        new ::grpc::internal::StreamedUnaryHandler< ::tortuga::Worker, ::google::protobuf::Empty>(std::bind(&WithStreamedUnaryMethod_Heartbeat<BaseClass>::StreamedHeartbeat, this, std::placeholders::_1, std::placeholders::_2)));
+        new ::grpc::internal::StreamedUnaryHandler< ::tortuga::HeartbeatReq, ::google::protobuf::Empty>(std::bind(&WithStreamedUnaryMethod_Heartbeat<BaseClass>::StreamedHeartbeat, this, std::placeholders::_1, std::placeholders::_2)));
     }
     ~WithStreamedUnaryMethod_Heartbeat() override {
       BaseClassMustBeDerivedFromService(this);
     }
     // disable regular version of this method
-    ::grpc::Status Heartbeat(::grpc::ServerContext* context, const ::tortuga::Worker* request, ::google::protobuf::Empty* response) final override {
+    ::grpc::Status Heartbeat(::grpc::ServerContext* context, const ::tortuga::HeartbeatReq* request, ::google::protobuf::Empty* response) final override {
       abort();
       return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
     }
     // replace default version of method with streamed unary
-    virtual ::grpc::Status StreamedHeartbeat(::grpc::ServerContext* context, ::grpc::ServerUnaryStreamer< ::tortuga::Worker,::google::protobuf::Empty>* server_unary_streamer) = 0;
+    virtual ::grpc::Status StreamedHeartbeat(::grpc::ServerContext* context, ::grpc::ServerUnaryStreamer< ::tortuga::HeartbeatReq,::google::protobuf::Empty>* server_unary_streamer) = 0;
   };
   template <class BaseClass>
   class WithStreamedUnaryMethod_CompleteTask : public BaseClass {

--- a/tortuga/tortuga.pb.cc
+++ b/tortuga/tortuga.pb.cc
@@ -25,11 +25,16 @@ class WorkerDefaultTypeInternal {
   ::google::protobuf::internal::ExplicitlyConstructed<Worker>
       _instance;
 } _Worker_default_instance_;
-class HeartbeatDefaultTypeInternal {
+class HeartbeatReq_WorkerBeatDefaultTypeInternal {
  public:
-  ::google::protobuf::internal::ExplicitlyConstructed<Heartbeat>
+  ::google::protobuf::internal::ExplicitlyConstructed<HeartbeatReq_WorkerBeat>
       _instance;
-} _Heartbeat_default_instance_;
+} _HeartbeatReq_WorkerBeat_default_instance_;
+class HeartbeatReqDefaultTypeInternal {
+ public:
+  ::google::protobuf::internal::ExplicitlyConstructed<HeartbeatReq>
+      _instance;
+} _HeartbeatReq_default_instance_;
 class TaskReqDefaultTypeInternal {
  public:
   ::google::protobuf::internal::ExplicitlyConstructed<TaskReq>
@@ -113,7 +118,7 @@ void InitDefaultsWorker() {
   ::google::protobuf::GoogleOnceInit(&once, &InitDefaultsWorkerImpl);
 }
 
-void InitDefaultsHeartbeatImpl() {
+void InitDefaultsHeartbeatReq_WorkerBeatImpl() {
   GOOGLE_PROTOBUF_VERIFY_VERSION;
 
 #ifdef GOOGLE_PROTOBUF_ENFORCE_UNIQUENESS
@@ -123,16 +128,38 @@ void InitDefaultsHeartbeatImpl() {
 #endif  // GOOGLE_PROTOBUF_ENFORCE_UNIQUENESS
   protobuf_tortuga_2ftortuga_2eproto::InitDefaultsWorker();
   {
-    void* ptr = &::tortuga::_Heartbeat_default_instance_;
-    new (ptr) ::tortuga::Heartbeat();
+    void* ptr = &::tortuga::_HeartbeatReq_WorkerBeat_default_instance_;
+    new (ptr) ::tortuga::HeartbeatReq_WorkerBeat();
     ::google::protobuf::internal::OnShutdownDestroyMessage(ptr);
   }
-  ::tortuga::Heartbeat::InitAsDefaultInstance();
+  ::tortuga::HeartbeatReq_WorkerBeat::InitAsDefaultInstance();
 }
 
-void InitDefaultsHeartbeat() {
+void InitDefaultsHeartbeatReq_WorkerBeat() {
   static GOOGLE_PROTOBUF_DECLARE_ONCE(once);
-  ::google::protobuf::GoogleOnceInit(&once, &InitDefaultsHeartbeatImpl);
+  ::google::protobuf::GoogleOnceInit(&once, &InitDefaultsHeartbeatReq_WorkerBeatImpl);
+}
+
+void InitDefaultsHeartbeatReqImpl() {
+  GOOGLE_PROTOBUF_VERIFY_VERSION;
+
+#ifdef GOOGLE_PROTOBUF_ENFORCE_UNIQUENESS
+  ::google::protobuf::internal::InitProtobufDefaultsForceUnique();
+#else
+  ::google::protobuf::internal::InitProtobufDefaults();
+#endif  // GOOGLE_PROTOBUF_ENFORCE_UNIQUENESS
+  protobuf_tortuga_2ftortuga_2eproto::InitDefaultsHeartbeatReq_WorkerBeat();
+  {
+    void* ptr = &::tortuga::_HeartbeatReq_default_instance_;
+    new (ptr) ::tortuga::HeartbeatReq();
+    ::google::protobuf::internal::OnShutdownDestroyMessage(ptr);
+  }
+  ::tortuga::HeartbeatReq::InitAsDefaultInstance();
+}
+
+void InitDefaultsHeartbeatReq() {
+  static GOOGLE_PROTOBUF_DECLARE_ONCE(once);
+  ::google::protobuf::GoogleOnceInit(&once, &InitDefaultsHeartbeatReqImpl);
 }
 
 void InitDefaultsTaskReqImpl() {
@@ -401,7 +428,7 @@ void InitDefaultsTaskIdentifier() {
   ::google::protobuf::GoogleOnceInit(&once, &InitDefaultsTaskIdentifierImpl);
 }
 
-::google::protobuf::Metadata file_level_metadata[14];
+::google::protobuf::Metadata file_level_metadata[15];
 
 const ::google::protobuf::uint32 TableStruct::offsets[] GOOGLE_PROTOBUF_ATTRIBUTE_SECTION_VARIABLE(protodesc_cold) = {
   ~0u,  // no _has_bits_
@@ -413,12 +440,18 @@ const ::google::protobuf::uint32 TableStruct::offsets[] GOOGLE_PROTOBUF_ATTRIBUT
   GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(::tortuga::Worker, uuid_),
   GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(::tortuga::Worker, capabilities_),
   ~0u,  // no _has_bits_
-  GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(::tortuga::Heartbeat, _internal_metadata_),
+  GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(::tortuga::HeartbeatReq_WorkerBeat, _internal_metadata_),
   ~0u,  // no _extensions_
   ~0u,  // no _oneof_case_
   ~0u,  // no _weak_field_map_
-  GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(::tortuga::Heartbeat, worker_),
-  GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(::tortuga::Heartbeat, current_task_handles_),
+  GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(::tortuga::HeartbeatReq_WorkerBeat, worker_),
+  GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(::tortuga::HeartbeatReq_WorkerBeat, current_task_handles_),
+  ~0u,  // no _has_bits_
+  GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(::tortuga::HeartbeatReq, _internal_metadata_),
+  ~0u,  // no _extensions_
+  ~0u,  // no _oneof_case_
+  ~0u,  // no _weak_field_map_
+  GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(::tortuga::HeartbeatReq, worker_beats_),
   ~0u,  // no _has_bits_
   GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(::tortuga::TaskReq, _internal_metadata_),
   ~0u,  // no _extensions_
@@ -535,24 +568,26 @@ const ::google::protobuf::uint32 TableStruct::offsets[] GOOGLE_PROTOBUF_ATTRIBUT
 };
 static const ::google::protobuf::internal::MigrationSchema schemas[] GOOGLE_PROTOBUF_ATTRIBUTE_SECTION_VARIABLE(protodesc_cold) = {
   { 0, -1, sizeof(::tortuga::Worker)},
-  { 8, -1, sizeof(::tortuga::Heartbeat)},
-  { 15, -1, sizeof(::tortuga::TaskReq)},
-  { 21, -1, sizeof(::tortuga::TaskResp_RetryContext)},
-  { 28, -1, sizeof(::tortuga::TaskResp)},
-  { 39, -1, sizeof(::tortuga::Task)},
-  { 51, -1, sizeof(::tortuga::TaskProgress)},
-  { 74, -1, sizeof(::tortuga::CreateReq)},
-  { 80, -1, sizeof(::tortuga::CreateResp)},
-  { 87, -1, sizeof(::tortuga::CompleteTaskReq)},
-  { 98, -1, sizeof(::tortuga::UpdateProgressReq)},
-  { 108, -1, sizeof(::tortuga::ProgressReq)},
-  { 114, -1, sizeof(::tortuga::ProgressResp)},
-  { 121, -1, sizeof(::tortuga::TaskIdentifier)},
+  { 8, -1, sizeof(::tortuga::HeartbeatReq_WorkerBeat)},
+  { 15, -1, sizeof(::tortuga::HeartbeatReq)},
+  { 21, -1, sizeof(::tortuga::TaskReq)},
+  { 27, -1, sizeof(::tortuga::TaskResp_RetryContext)},
+  { 34, -1, sizeof(::tortuga::TaskResp)},
+  { 45, -1, sizeof(::tortuga::Task)},
+  { 57, -1, sizeof(::tortuga::TaskProgress)},
+  { 80, -1, sizeof(::tortuga::CreateReq)},
+  { 86, -1, sizeof(::tortuga::CreateResp)},
+  { 93, -1, sizeof(::tortuga::CompleteTaskReq)},
+  { 104, -1, sizeof(::tortuga::UpdateProgressReq)},
+  { 114, -1, sizeof(::tortuga::ProgressReq)},
+  { 120, -1, sizeof(::tortuga::ProgressResp)},
+  { 127, -1, sizeof(::tortuga::TaskIdentifier)},
 };
 
 static ::google::protobuf::Message const * const file_default_instances[] = {
   reinterpret_cast<const ::google::protobuf::Message*>(&::tortuga::_Worker_default_instance_),
-  reinterpret_cast<const ::google::protobuf::Message*>(&::tortuga::_Heartbeat_default_instance_),
+  reinterpret_cast<const ::google::protobuf::Message*>(&::tortuga::_HeartbeatReq_WorkerBeat_default_instance_),
+  reinterpret_cast<const ::google::protobuf::Message*>(&::tortuga::_HeartbeatReq_default_instance_),
   reinterpret_cast<const ::google::protobuf::Message*>(&::tortuga::_TaskReq_default_instance_),
   reinterpret_cast<const ::google::protobuf::Message*>(&::tortuga::_TaskResp_RetryContext_default_instance_),
   reinterpret_cast<const ::google::protobuf::Message*>(&::tortuga::_TaskResp_default_instance_),
@@ -583,7 +618,7 @@ void protobuf_AssignDescriptorsOnce() {
 void protobuf_RegisterTypes(const ::std::string&) GOOGLE_PROTOBUF_ATTRIBUTE_COLD;
 void protobuf_RegisterTypes(const ::std::string&) {
   protobuf_AssignDescriptorsOnce();
-  ::google::protobuf::internal::RegisterAllTypes(file_level_metadata, 14);
+  ::google::protobuf::internal::RegisterAllTypes(file_level_metadata, 15);
 }
 
 void AddDescriptorsImpl() {
@@ -595,51 +630,53 @@ void AddDescriptorsImpl() {
       "\032\037google/protobuf/timestamp.proto\032\036googl"
       "e/protobuf/wrappers.proto\032\027google/rpc/st"
       "atus.proto\"\?\n\006Worker\022\021\n\tworker_id\030\001 \001(\t\022"
-      "\014\n\004uuid\030\002 \001(\t\022\024\n\014capabilities\030\003 \003(\t\"J\n\tH"
-      "eartbeat\022\037\n\006worker\030\001 \001(\0132\017.tortuga.Worke"
-      "r\022\034\n\024current_task_handles\030\002 \003(\003\"*\n\007TaskR"
-      "eq\022\037\n\006worker\030\001 \001(\0132\017.tortuga.Worker\"\325\001\n\010"
-      "TaskResp\022\n\n\002id\030\001 \001(\t\022\014\n\004type\030\002 \001(\t\022\"\n\004da"
-      "ta\030\003 \001(\0132\024.google.protobuf.Any\022\016\n\006handle"
-      "\030\004 \001(\t\022\014\n\004none\030\005 \001(\010\0221\n\tretry_ctx\030\006 \001(\0132"
-      "\036.tortuga.TaskResp.RetryContext\032:\n\014Retry"
-      "Context\022\017\n\007retries\030\001 \001(\005\022\031\n\021progress_met"
-      "adata\030\002 \001(\t\"\340\001\n\004Task\022\n\n\002id\030\001 \001(\t\022\014\n\004type"
-      "\030\002 \001(\t\022\"\n\004data\030\003 \001(\0132\024.google.protobuf.A"
-      "ny\022-\n\010priority\030\004 \001(\0132\033.google.protobuf.I"
-      "nt32Value\0220\n\013max_retries\030\005 \001(\0132\033.google."
-      "protobuf.Int32Value\022(\n\005delay\030\006 \001(\0132\031.goo"
-      "gle.protobuf.Duration\022\017\n\007modules\030\007 \003(\t\"\273"
-      "\003\n\014TaskProgress\022\016\n\006handle\030\001 \001(\t\022\n\n\002id\030\002 "
-      "\001(\t\022\014\n\004type\030\003 \001(\t\022\023\n\013max_retries\030\004 \001(\005\022\017"
-      "\n\007retries\030\005 \001(\005\022\020\n\010priority\030\006 \001(\005\022\021\n\twor"
-      "ked_on\030\007 \001(\010\022\014\n\004done\030\010 \001(\010\022+\n\007created\030\t "
-      "\001(\0132\032.google.protobuf.Timestamp\0220\n\014start"
-      "ed_time\030\n \001(\0132\032.google.protobuf.Timestam"
-      "p\022-\n\tdone_time\030\013 \001(\0132\032.google.protobuf.T"
-      "imestamp\022\"\n\006status\030\014 \001(\0132\022.google.rpc.St"
-      "atus\022\020\n\010progress\030\r \001(\002\022\030\n\020progress_messa"
-      "ge\030\016 \001(\t\022\031\n\021progress_metadata\030\022 \001(\t\022\014\n\004l"
-      "ogs\030\017 \001(\t\022\021\n\tworker_id\030\020 \001(\t\022\016\n\006output\030\021"
-      " \001(\t\"(\n\tCreateReq\022\033\n\004task\030\001 \001(\0132\r.tortug"
-      "a.Task\"-\n\nCreateResp\022\016\n\006handle\030\001 \001(\t\022\017\n\007"
-      "created\030\002 \001(\010\"\205\001\n\017CompleteTaskReq\022\037\n\006wor"
-      "ker\030\001 \001(\0132\017.tortuga.Worker\022\016\n\006handle\030\002 \001"
-      "(\t\022\014\n\004code\030\003 \001(\005\022\025\n\rerror_message\030\004 \001(\t\022"
-      "\014\n\004logs\030\005 \001(\t\022\016\n\006output\030\006 \001(\t\"\344\001\n\021Update"
-      "ProgressReq\022\037\n\006worker\030\001 \001(\0132\017.tortuga.Wo"
-      "rker\022\016\n\006handle\030\002 \001(\t\022-\n\010progress\030\003 \001(\0132\033"
-      ".google.protobuf.FloatValue\0226\n\020progress_"
-      "message\030\004 \001(\0132\034.google.protobuf.StringVa"
-      "lue\0227\n\021progress_metadata\030\005 \001(\0132\034.google."
-      "protobuf.StringValue\"\035\n\013ProgressReq\022\016\n\006h"
-      "andle\030\001 \001(\t\"B\n\014ProgressResp\022\016\n\006handle\030\001 "
-      "\001(\t\022\"\n\006status\030\002 \001(\0132\022.google.rpc.Status\""
-      "*\n\016TaskIdentifier\022\n\n\002id\030\001 \001(\t\022\014\n\004type\030\002 "
-      "\001(\t2\257\004\n\007Tortuga\0225\n\nCreateTask\022\022.tortuga."
-      "CreateReq\032\023.tortuga.CreateResp\0222\n\013Reques"
-      "tTask\022\020.tortuga.TaskReq\032\021.tortuga.TaskRe"
-      "sp\0224\n\tHeartbeat\022\017.tortuga.Worker\032\026.googl"
+      "\014\n\004uuid\030\002 \001(\t\022\024\n\014capabilities\030\003 \003(\t\"\223\001\n\014"
+      "HeartbeatReq\0226\n\014worker_beats\030\001 \003(\0132 .tor"
+      "tuga.HeartbeatReq.WorkerBeat\032K\n\nWorkerBe"
+      "at\022\037\n\006worker\030\001 \001(\0132\017.tortuga.Worker\022\034\n\024c"
+      "urrent_task_handles\030\002 \003(\003\"*\n\007TaskReq\022\037\n\006"
+      "worker\030\001 \001(\0132\017.tortuga.Worker\"\325\001\n\010TaskRe"
+      "sp\022\n\n\002id\030\001 \001(\t\022\014\n\004type\030\002 \001(\t\022\"\n\004data\030\003 \001"
+      "(\0132\024.google.protobuf.Any\022\016\n\006handle\030\004 \001(\t"
+      "\022\014\n\004none\030\005 \001(\010\0221\n\tretry_ctx\030\006 \001(\0132\036.tort"
+      "uga.TaskResp.RetryContext\032:\n\014RetryContex"
+      "t\022\017\n\007retries\030\001 \001(\005\022\031\n\021progress_metadata\030"
+      "\002 \001(\t\"\340\001\n\004Task\022\n\n\002id\030\001 \001(\t\022\014\n\004type\030\002 \001(\t"
+      "\022\"\n\004data\030\003 \001(\0132\024.google.protobuf.Any\022-\n\010"
+      "priority\030\004 \001(\0132\033.google.protobuf.Int32Va"
+      "lue\0220\n\013max_retries\030\005 \001(\0132\033.google.protob"
+      "uf.Int32Value\022(\n\005delay\030\006 \001(\0132\031.google.pr"
+      "otobuf.Duration\022\017\n\007modules\030\007 \003(\t\"\273\003\n\014Tas"
+      "kProgress\022\016\n\006handle\030\001 \001(\t\022\n\n\002id\030\002 \001(\t\022\014\n"
+      "\004type\030\003 \001(\t\022\023\n\013max_retries\030\004 \001(\005\022\017\n\007retr"
+      "ies\030\005 \001(\005\022\020\n\010priority\030\006 \001(\005\022\021\n\tworked_on"
+      "\030\007 \001(\010\022\014\n\004done\030\010 \001(\010\022+\n\007created\030\t \001(\0132\032."
+      "google.protobuf.Timestamp\0220\n\014started_tim"
+      "e\030\n \001(\0132\032.google.protobuf.Timestamp\022-\n\td"
+      "one_time\030\013 \001(\0132\032.google.protobuf.Timesta"
+      "mp\022\"\n\006status\030\014 \001(\0132\022.google.rpc.Status\022\020"
+      "\n\010progress\030\r \001(\002\022\030\n\020progress_message\030\016 \001"
+      "(\t\022\031\n\021progress_metadata\030\022 \001(\t\022\014\n\004logs\030\017 "
+      "\001(\t\022\021\n\tworker_id\030\020 \001(\t\022\016\n\006output\030\021 \001(\t\"("
+      "\n\tCreateReq\022\033\n\004task\030\001 \001(\0132\r.tortuga.Task"
+      "\"-\n\nCreateResp\022\016\n\006handle\030\001 \001(\t\022\017\n\007create"
+      "d\030\002 \001(\010\"\205\001\n\017CompleteTaskReq\022\037\n\006worker\030\001 "
+      "\001(\0132\017.tortuga.Worker\022\016\n\006handle\030\002 \001(\t\022\014\n\004"
+      "code\030\003 \001(\005\022\025\n\rerror_message\030\004 \001(\t\022\014\n\004log"
+      "s\030\005 \001(\t\022\016\n\006output\030\006 \001(\t\"\344\001\n\021UpdateProgre"
+      "ssReq\022\037\n\006worker\030\001 \001(\0132\017.tortuga.Worker\022\016"
+      "\n\006handle\030\002 \001(\t\022-\n\010progress\030\003 \001(\0132\033.googl"
+      "e.protobuf.FloatValue\0226\n\020progress_messag"
+      "e\030\004 \001(\0132\034.google.protobuf.StringValue\0227\n"
+      "\021progress_metadata\030\005 \001(\0132\034.google.protob"
+      "uf.StringValue\"\035\n\013ProgressReq\022\016\n\006handle\030"
+      "\001 \001(\t\"B\n\014ProgressResp\022\016\n\006handle\030\001 \001(\t\022\"\n"
+      "\006status\030\002 \001(\0132\022.google.rpc.Status\"*\n\016Tas"
+      "kIdentifier\022\n\n\002id\030\001 \001(\t\022\014\n\004type\030\002 \001(\t2\265\004"
+      "\n\007Tortuga\0225\n\nCreateTask\022\022.tortuga.Create"
+      "Req\032\023.tortuga.CreateResp\0222\n\013RequestTask\022"
+      "\020.tortuga.TaskReq\032\021.tortuga.TaskResp\022:\n\t"
+      "Heartbeat\022\025.tortuga.HeartbeatReq\032\026.googl"
       "e.protobuf.Empty\022@\n\014CompleteTask\022\030.tortu"
       "ga.CompleteTaskReq\032\026.google.protobuf.Emp"
       "ty\022D\n\016UpdateProgress\022\032.tortuga.UpdatePro"
@@ -654,7 +691,7 @@ void AddDescriptorsImpl() {
       "3"
   };
   ::google::protobuf::DescriptorPool::InternalAddGeneratedFile(
-      descriptor, 2481);
+      descriptor, 2561);
   ::google::protobuf::MessageFactory::InternalRegisterGeneratedFile(
     "tortuga/tortuga.proto", &protobuf_RegisterTypes);
   ::protobuf_google_2fprotobuf_2fany_2eproto::AddDescriptors();
@@ -1043,24 +1080,24 @@ void Worker::InternalSwap(Worker* other) {
 
 // ===================================================================
 
-void Heartbeat::InitAsDefaultInstance() {
-  ::tortuga::_Heartbeat_default_instance_._instance.get_mutable()->worker_ = const_cast< ::tortuga::Worker*>(
+void HeartbeatReq_WorkerBeat::InitAsDefaultInstance() {
+  ::tortuga::_HeartbeatReq_WorkerBeat_default_instance_._instance.get_mutable()->worker_ = const_cast< ::tortuga::Worker*>(
       ::tortuga::Worker::internal_default_instance());
 }
 #if !defined(_MSC_VER) || _MSC_VER >= 1900
-const int Heartbeat::kWorkerFieldNumber;
-const int Heartbeat::kCurrentTaskHandlesFieldNumber;
+const int HeartbeatReq_WorkerBeat::kWorkerFieldNumber;
+const int HeartbeatReq_WorkerBeat::kCurrentTaskHandlesFieldNumber;
 #endif  // !defined(_MSC_VER) || _MSC_VER >= 1900
 
-Heartbeat::Heartbeat()
+HeartbeatReq_WorkerBeat::HeartbeatReq_WorkerBeat()
   : ::google::protobuf::Message(), _internal_metadata_(NULL) {
   if (GOOGLE_PREDICT_TRUE(this != internal_default_instance())) {
-    ::protobuf_tortuga_2ftortuga_2eproto::InitDefaultsHeartbeat();
+    ::protobuf_tortuga_2ftortuga_2eproto::InitDefaultsHeartbeatReq_WorkerBeat();
   }
   SharedCtor();
-  // @@protoc_insertion_point(constructor:tortuga.Heartbeat)
+  // @@protoc_insertion_point(constructor:tortuga.HeartbeatReq.WorkerBeat)
 }
-Heartbeat::Heartbeat(const Heartbeat& from)
+HeartbeatReq_WorkerBeat::HeartbeatReq_WorkerBeat(const HeartbeatReq_WorkerBeat& from)
   : ::google::protobuf::Message(),
       _internal_metadata_(NULL),
       current_task_handles_(from.current_task_handles_),
@@ -1071,48 +1108,48 @@ Heartbeat::Heartbeat(const Heartbeat& from)
   } else {
     worker_ = NULL;
   }
-  // @@protoc_insertion_point(copy_constructor:tortuga.Heartbeat)
+  // @@protoc_insertion_point(copy_constructor:tortuga.HeartbeatReq.WorkerBeat)
 }
 
-void Heartbeat::SharedCtor() {
+void HeartbeatReq_WorkerBeat::SharedCtor() {
   worker_ = NULL;
   _cached_size_ = 0;
 }
 
-Heartbeat::~Heartbeat() {
-  // @@protoc_insertion_point(destructor:tortuga.Heartbeat)
+HeartbeatReq_WorkerBeat::~HeartbeatReq_WorkerBeat() {
+  // @@protoc_insertion_point(destructor:tortuga.HeartbeatReq.WorkerBeat)
   SharedDtor();
 }
 
-void Heartbeat::SharedDtor() {
+void HeartbeatReq_WorkerBeat::SharedDtor() {
   if (this != internal_default_instance()) delete worker_;
 }
 
-void Heartbeat::SetCachedSize(int size) const {
+void HeartbeatReq_WorkerBeat::SetCachedSize(int size) const {
   GOOGLE_SAFE_CONCURRENT_WRITES_BEGIN();
   _cached_size_ = size;
   GOOGLE_SAFE_CONCURRENT_WRITES_END();
 }
-const ::google::protobuf::Descriptor* Heartbeat::descriptor() {
+const ::google::protobuf::Descriptor* HeartbeatReq_WorkerBeat::descriptor() {
   ::protobuf_tortuga_2ftortuga_2eproto::protobuf_AssignDescriptorsOnce();
   return ::protobuf_tortuga_2ftortuga_2eproto::file_level_metadata[kIndexInFileMessages].descriptor;
 }
 
-const Heartbeat& Heartbeat::default_instance() {
-  ::protobuf_tortuga_2ftortuga_2eproto::InitDefaultsHeartbeat();
+const HeartbeatReq_WorkerBeat& HeartbeatReq_WorkerBeat::default_instance() {
+  ::protobuf_tortuga_2ftortuga_2eproto::InitDefaultsHeartbeatReq_WorkerBeat();
   return *internal_default_instance();
 }
 
-Heartbeat* Heartbeat::New(::google::protobuf::Arena* arena) const {
-  Heartbeat* n = new Heartbeat;
+HeartbeatReq_WorkerBeat* HeartbeatReq_WorkerBeat::New(::google::protobuf::Arena* arena) const {
+  HeartbeatReq_WorkerBeat* n = new HeartbeatReq_WorkerBeat;
   if (arena != NULL) {
     arena->Own(n);
   }
   return n;
 }
 
-void Heartbeat::Clear() {
-// @@protoc_insertion_point(message_clear_start:tortuga.Heartbeat)
+void HeartbeatReq_WorkerBeat::Clear() {
+// @@protoc_insertion_point(message_clear_start:tortuga.HeartbeatReq.WorkerBeat)
   ::google::protobuf::uint32 cached_has_bits = 0;
   // Prevent compiler warnings about cached_has_bits being unused
   (void) cached_has_bits;
@@ -1125,11 +1162,11 @@ void Heartbeat::Clear() {
   _internal_metadata_.Clear();
 }
 
-bool Heartbeat::MergePartialFromCodedStream(
+bool HeartbeatReq_WorkerBeat::MergePartialFromCodedStream(
     ::google::protobuf::io::CodedInputStream* input) {
 #define DO_(EXPRESSION) if (!GOOGLE_PREDICT_TRUE(EXPRESSION)) goto failure
   ::google::protobuf::uint32 tag;
-  // @@protoc_insertion_point(parse_start:tortuga.Heartbeat)
+  // @@protoc_insertion_point(parse_start:tortuga.HeartbeatReq.WorkerBeat)
   for (;;) {
     ::std::pair< ::google::protobuf::uint32, bool> p = input->ReadTagWithCutoffNoLastTag(127u);
     tag = p.first;
@@ -1178,17 +1215,17 @@ bool Heartbeat::MergePartialFromCodedStream(
     }
   }
 success:
-  // @@protoc_insertion_point(parse_success:tortuga.Heartbeat)
+  // @@protoc_insertion_point(parse_success:tortuga.HeartbeatReq.WorkerBeat)
   return true;
 failure:
-  // @@protoc_insertion_point(parse_failure:tortuga.Heartbeat)
+  // @@protoc_insertion_point(parse_failure:tortuga.HeartbeatReq.WorkerBeat)
   return false;
 #undef DO_
 }
 
-void Heartbeat::SerializeWithCachedSizes(
+void HeartbeatReq_WorkerBeat::SerializeWithCachedSizes(
     ::google::protobuf::io::CodedOutputStream* output) const {
-  // @@protoc_insertion_point(serialize_start:tortuga.Heartbeat)
+  // @@protoc_insertion_point(serialize_start:tortuga.HeartbeatReq.WorkerBeat)
   ::google::protobuf::uint32 cached_has_bits = 0;
   (void) cached_has_bits;
 
@@ -1213,13 +1250,13 @@ void Heartbeat::SerializeWithCachedSizes(
     ::google::protobuf::internal::WireFormat::SerializeUnknownFields(
         (::google::protobuf::internal::GetProto3PreserveUnknownsDefault()   ? _internal_metadata_.unknown_fields()   : _internal_metadata_.default_instance()), output);
   }
-  // @@protoc_insertion_point(serialize_end:tortuga.Heartbeat)
+  // @@protoc_insertion_point(serialize_end:tortuga.HeartbeatReq.WorkerBeat)
 }
 
-::google::protobuf::uint8* Heartbeat::InternalSerializeWithCachedSizesToArray(
+::google::protobuf::uint8* HeartbeatReq_WorkerBeat::InternalSerializeWithCachedSizesToArray(
     bool deterministic, ::google::protobuf::uint8* target) const {
   (void)deterministic; // Unused
-  // @@protoc_insertion_point(serialize_to_array_start:tortuga.Heartbeat)
+  // @@protoc_insertion_point(serialize_to_array_start:tortuga.HeartbeatReq.WorkerBeat)
   ::google::protobuf::uint32 cached_has_bits = 0;
   (void) cached_has_bits;
 
@@ -1247,12 +1284,12 @@ void Heartbeat::SerializeWithCachedSizes(
     target = ::google::protobuf::internal::WireFormat::SerializeUnknownFieldsToArray(
         (::google::protobuf::internal::GetProto3PreserveUnknownsDefault()   ? _internal_metadata_.unknown_fields()   : _internal_metadata_.default_instance()), target);
   }
-  // @@protoc_insertion_point(serialize_to_array_end:tortuga.Heartbeat)
+  // @@protoc_insertion_point(serialize_to_array_end:tortuga.HeartbeatReq.WorkerBeat)
   return target;
 }
 
-size_t Heartbeat::ByteSizeLong() const {
-// @@protoc_insertion_point(message_byte_size_start:tortuga.Heartbeat)
+size_t HeartbeatReq_WorkerBeat::ByteSizeLong() const {
+// @@protoc_insertion_point(message_byte_size_start:tortuga.HeartbeatReq.WorkerBeat)
   size_t total_size = 0;
 
   if ((_internal_metadata_.have_unknown_fields() &&  ::google::protobuf::internal::GetProto3PreserveUnknownsDefault())) {
@@ -1290,23 +1327,23 @@ size_t Heartbeat::ByteSizeLong() const {
   return total_size;
 }
 
-void Heartbeat::MergeFrom(const ::google::protobuf::Message& from) {
-// @@protoc_insertion_point(generalized_merge_from_start:tortuga.Heartbeat)
+void HeartbeatReq_WorkerBeat::MergeFrom(const ::google::protobuf::Message& from) {
+// @@protoc_insertion_point(generalized_merge_from_start:tortuga.HeartbeatReq.WorkerBeat)
   GOOGLE_DCHECK_NE(&from, this);
-  const Heartbeat* source =
-      ::google::protobuf::internal::DynamicCastToGenerated<const Heartbeat>(
+  const HeartbeatReq_WorkerBeat* source =
+      ::google::protobuf::internal::DynamicCastToGenerated<const HeartbeatReq_WorkerBeat>(
           &from);
   if (source == NULL) {
-  // @@protoc_insertion_point(generalized_merge_from_cast_fail:tortuga.Heartbeat)
+  // @@protoc_insertion_point(generalized_merge_from_cast_fail:tortuga.HeartbeatReq.WorkerBeat)
     ::google::protobuf::internal::ReflectionOps::Merge(from, this);
   } else {
-  // @@protoc_insertion_point(generalized_merge_from_cast_success:tortuga.Heartbeat)
+  // @@protoc_insertion_point(generalized_merge_from_cast_success:tortuga.HeartbeatReq.WorkerBeat)
     MergeFrom(*source);
   }
 }
 
-void Heartbeat::MergeFrom(const Heartbeat& from) {
-// @@protoc_insertion_point(class_specific_merge_from_start:tortuga.Heartbeat)
+void HeartbeatReq_WorkerBeat::MergeFrom(const HeartbeatReq_WorkerBeat& from) {
+// @@protoc_insertion_point(class_specific_merge_from_start:tortuga.HeartbeatReq.WorkerBeat)
   GOOGLE_DCHECK_NE(&from, this);
   _internal_metadata_.MergeFrom(from._internal_metadata_);
   ::google::protobuf::uint32 cached_has_bits = 0;
@@ -1318,29 +1355,29 @@ void Heartbeat::MergeFrom(const Heartbeat& from) {
   }
 }
 
-void Heartbeat::CopyFrom(const ::google::protobuf::Message& from) {
-// @@protoc_insertion_point(generalized_copy_from_start:tortuga.Heartbeat)
+void HeartbeatReq_WorkerBeat::CopyFrom(const ::google::protobuf::Message& from) {
+// @@protoc_insertion_point(generalized_copy_from_start:tortuga.HeartbeatReq.WorkerBeat)
   if (&from == this) return;
   Clear();
   MergeFrom(from);
 }
 
-void Heartbeat::CopyFrom(const Heartbeat& from) {
-// @@protoc_insertion_point(class_specific_copy_from_start:tortuga.Heartbeat)
+void HeartbeatReq_WorkerBeat::CopyFrom(const HeartbeatReq_WorkerBeat& from) {
+// @@protoc_insertion_point(class_specific_copy_from_start:tortuga.HeartbeatReq.WorkerBeat)
   if (&from == this) return;
   Clear();
   MergeFrom(from);
 }
 
-bool Heartbeat::IsInitialized() const {
+bool HeartbeatReq_WorkerBeat::IsInitialized() const {
   return true;
 }
 
-void Heartbeat::Swap(Heartbeat* other) {
+void HeartbeatReq_WorkerBeat::Swap(HeartbeatReq_WorkerBeat* other) {
   if (other == this) return;
   InternalSwap(other);
 }
-void Heartbeat::InternalSwap(Heartbeat* other) {
+void HeartbeatReq_WorkerBeat::InternalSwap(HeartbeatReq_WorkerBeat* other) {
   using std::swap;
   current_task_handles_.InternalSwap(&other->current_task_handles_);
   swap(worker_, other->worker_);
@@ -1348,7 +1385,248 @@ void Heartbeat::InternalSwap(Heartbeat* other) {
   swap(_cached_size_, other->_cached_size_);
 }
 
-::google::protobuf::Metadata Heartbeat::GetMetadata() const {
+::google::protobuf::Metadata HeartbeatReq_WorkerBeat::GetMetadata() const {
+  protobuf_tortuga_2ftortuga_2eproto::protobuf_AssignDescriptorsOnce();
+  return ::protobuf_tortuga_2ftortuga_2eproto::file_level_metadata[kIndexInFileMessages];
+}
+
+
+// ===================================================================
+
+void HeartbeatReq::InitAsDefaultInstance() {
+}
+#if !defined(_MSC_VER) || _MSC_VER >= 1900
+const int HeartbeatReq::kWorkerBeatsFieldNumber;
+#endif  // !defined(_MSC_VER) || _MSC_VER >= 1900
+
+HeartbeatReq::HeartbeatReq()
+  : ::google::protobuf::Message(), _internal_metadata_(NULL) {
+  if (GOOGLE_PREDICT_TRUE(this != internal_default_instance())) {
+    ::protobuf_tortuga_2ftortuga_2eproto::InitDefaultsHeartbeatReq();
+  }
+  SharedCtor();
+  // @@protoc_insertion_point(constructor:tortuga.HeartbeatReq)
+}
+HeartbeatReq::HeartbeatReq(const HeartbeatReq& from)
+  : ::google::protobuf::Message(),
+      _internal_metadata_(NULL),
+      worker_beats_(from.worker_beats_),
+      _cached_size_(0) {
+  _internal_metadata_.MergeFrom(from._internal_metadata_);
+  // @@protoc_insertion_point(copy_constructor:tortuga.HeartbeatReq)
+}
+
+void HeartbeatReq::SharedCtor() {
+  _cached_size_ = 0;
+}
+
+HeartbeatReq::~HeartbeatReq() {
+  // @@protoc_insertion_point(destructor:tortuga.HeartbeatReq)
+  SharedDtor();
+}
+
+void HeartbeatReq::SharedDtor() {
+}
+
+void HeartbeatReq::SetCachedSize(int size) const {
+  GOOGLE_SAFE_CONCURRENT_WRITES_BEGIN();
+  _cached_size_ = size;
+  GOOGLE_SAFE_CONCURRENT_WRITES_END();
+}
+const ::google::protobuf::Descriptor* HeartbeatReq::descriptor() {
+  ::protobuf_tortuga_2ftortuga_2eproto::protobuf_AssignDescriptorsOnce();
+  return ::protobuf_tortuga_2ftortuga_2eproto::file_level_metadata[kIndexInFileMessages].descriptor;
+}
+
+const HeartbeatReq& HeartbeatReq::default_instance() {
+  ::protobuf_tortuga_2ftortuga_2eproto::InitDefaultsHeartbeatReq();
+  return *internal_default_instance();
+}
+
+HeartbeatReq* HeartbeatReq::New(::google::protobuf::Arena* arena) const {
+  HeartbeatReq* n = new HeartbeatReq;
+  if (arena != NULL) {
+    arena->Own(n);
+  }
+  return n;
+}
+
+void HeartbeatReq::Clear() {
+// @@protoc_insertion_point(message_clear_start:tortuga.HeartbeatReq)
+  ::google::protobuf::uint32 cached_has_bits = 0;
+  // Prevent compiler warnings about cached_has_bits being unused
+  (void) cached_has_bits;
+
+  worker_beats_.Clear();
+  _internal_metadata_.Clear();
+}
+
+bool HeartbeatReq::MergePartialFromCodedStream(
+    ::google::protobuf::io::CodedInputStream* input) {
+#define DO_(EXPRESSION) if (!GOOGLE_PREDICT_TRUE(EXPRESSION)) goto failure
+  ::google::protobuf::uint32 tag;
+  // @@protoc_insertion_point(parse_start:tortuga.HeartbeatReq)
+  for (;;) {
+    ::std::pair< ::google::protobuf::uint32, bool> p = input->ReadTagWithCutoffNoLastTag(127u);
+    tag = p.first;
+    if (!p.second) goto handle_unusual;
+    switch (::google::protobuf::internal::WireFormatLite::GetTagFieldNumber(tag)) {
+      // repeated .tortuga.HeartbeatReq.WorkerBeat worker_beats = 1;
+      case 1: {
+        if (static_cast< ::google::protobuf::uint8>(tag) ==
+            static_cast< ::google::protobuf::uint8>(10u /* 10 & 0xFF */)) {
+          DO_(::google::protobuf::internal::WireFormatLite::ReadMessage(input, add_worker_beats()));
+        } else {
+          goto handle_unusual;
+        }
+        break;
+      }
+
+      default: {
+      handle_unusual:
+        if (tag == 0) {
+          goto success;
+        }
+        DO_(::google::protobuf::internal::WireFormat::SkipField(
+              input, tag, _internal_metadata_.mutable_unknown_fields()));
+        break;
+      }
+    }
+  }
+success:
+  // @@protoc_insertion_point(parse_success:tortuga.HeartbeatReq)
+  return true;
+failure:
+  // @@protoc_insertion_point(parse_failure:tortuga.HeartbeatReq)
+  return false;
+#undef DO_
+}
+
+void HeartbeatReq::SerializeWithCachedSizes(
+    ::google::protobuf::io::CodedOutputStream* output) const {
+  // @@protoc_insertion_point(serialize_start:tortuga.HeartbeatReq)
+  ::google::protobuf::uint32 cached_has_bits = 0;
+  (void) cached_has_bits;
+
+  // repeated .tortuga.HeartbeatReq.WorkerBeat worker_beats = 1;
+  for (unsigned int i = 0,
+      n = static_cast<unsigned int>(this->worker_beats_size()); i < n; i++) {
+    ::google::protobuf::internal::WireFormatLite::WriteMessageMaybeToArray(
+      1, this->worker_beats(static_cast<int>(i)), output);
+  }
+
+  if ((_internal_metadata_.have_unknown_fields() &&  ::google::protobuf::internal::GetProto3PreserveUnknownsDefault())) {
+    ::google::protobuf::internal::WireFormat::SerializeUnknownFields(
+        (::google::protobuf::internal::GetProto3PreserveUnknownsDefault()   ? _internal_metadata_.unknown_fields()   : _internal_metadata_.default_instance()), output);
+  }
+  // @@protoc_insertion_point(serialize_end:tortuga.HeartbeatReq)
+}
+
+::google::protobuf::uint8* HeartbeatReq::InternalSerializeWithCachedSizesToArray(
+    bool deterministic, ::google::protobuf::uint8* target) const {
+  (void)deterministic; // Unused
+  // @@protoc_insertion_point(serialize_to_array_start:tortuga.HeartbeatReq)
+  ::google::protobuf::uint32 cached_has_bits = 0;
+  (void) cached_has_bits;
+
+  // repeated .tortuga.HeartbeatReq.WorkerBeat worker_beats = 1;
+  for (unsigned int i = 0,
+      n = static_cast<unsigned int>(this->worker_beats_size()); i < n; i++) {
+    target = ::google::protobuf::internal::WireFormatLite::
+      InternalWriteMessageToArray(
+        1, this->worker_beats(static_cast<int>(i)), deterministic, target);
+  }
+
+  if ((_internal_metadata_.have_unknown_fields() &&  ::google::protobuf::internal::GetProto3PreserveUnknownsDefault())) {
+    target = ::google::protobuf::internal::WireFormat::SerializeUnknownFieldsToArray(
+        (::google::protobuf::internal::GetProto3PreserveUnknownsDefault()   ? _internal_metadata_.unknown_fields()   : _internal_metadata_.default_instance()), target);
+  }
+  // @@protoc_insertion_point(serialize_to_array_end:tortuga.HeartbeatReq)
+  return target;
+}
+
+size_t HeartbeatReq::ByteSizeLong() const {
+// @@protoc_insertion_point(message_byte_size_start:tortuga.HeartbeatReq)
+  size_t total_size = 0;
+
+  if ((_internal_metadata_.have_unknown_fields() &&  ::google::protobuf::internal::GetProto3PreserveUnknownsDefault())) {
+    total_size +=
+      ::google::protobuf::internal::WireFormat::ComputeUnknownFieldsSize(
+        (::google::protobuf::internal::GetProto3PreserveUnknownsDefault()   ? _internal_metadata_.unknown_fields()   : _internal_metadata_.default_instance()));
+  }
+  // repeated .tortuga.HeartbeatReq.WorkerBeat worker_beats = 1;
+  {
+    unsigned int count = static_cast<unsigned int>(this->worker_beats_size());
+    total_size += 1UL * count;
+    for (unsigned int i = 0; i < count; i++) {
+      total_size +=
+        ::google::protobuf::internal::WireFormatLite::MessageSize(
+          this->worker_beats(static_cast<int>(i)));
+    }
+  }
+
+  int cached_size = ::google::protobuf::internal::ToCachedSize(total_size);
+  GOOGLE_SAFE_CONCURRENT_WRITES_BEGIN();
+  _cached_size_ = cached_size;
+  GOOGLE_SAFE_CONCURRENT_WRITES_END();
+  return total_size;
+}
+
+void HeartbeatReq::MergeFrom(const ::google::protobuf::Message& from) {
+// @@protoc_insertion_point(generalized_merge_from_start:tortuga.HeartbeatReq)
+  GOOGLE_DCHECK_NE(&from, this);
+  const HeartbeatReq* source =
+      ::google::protobuf::internal::DynamicCastToGenerated<const HeartbeatReq>(
+          &from);
+  if (source == NULL) {
+  // @@protoc_insertion_point(generalized_merge_from_cast_fail:tortuga.HeartbeatReq)
+    ::google::protobuf::internal::ReflectionOps::Merge(from, this);
+  } else {
+  // @@protoc_insertion_point(generalized_merge_from_cast_success:tortuga.HeartbeatReq)
+    MergeFrom(*source);
+  }
+}
+
+void HeartbeatReq::MergeFrom(const HeartbeatReq& from) {
+// @@protoc_insertion_point(class_specific_merge_from_start:tortuga.HeartbeatReq)
+  GOOGLE_DCHECK_NE(&from, this);
+  _internal_metadata_.MergeFrom(from._internal_metadata_);
+  ::google::protobuf::uint32 cached_has_bits = 0;
+  (void) cached_has_bits;
+
+  worker_beats_.MergeFrom(from.worker_beats_);
+}
+
+void HeartbeatReq::CopyFrom(const ::google::protobuf::Message& from) {
+// @@protoc_insertion_point(generalized_copy_from_start:tortuga.HeartbeatReq)
+  if (&from == this) return;
+  Clear();
+  MergeFrom(from);
+}
+
+void HeartbeatReq::CopyFrom(const HeartbeatReq& from) {
+// @@protoc_insertion_point(class_specific_copy_from_start:tortuga.HeartbeatReq)
+  if (&from == this) return;
+  Clear();
+  MergeFrom(from);
+}
+
+bool HeartbeatReq::IsInitialized() const {
+  return true;
+}
+
+void HeartbeatReq::Swap(HeartbeatReq* other) {
+  if (other == this) return;
+  InternalSwap(other);
+}
+void HeartbeatReq::InternalSwap(HeartbeatReq* other) {
+  using std::swap;
+  worker_beats_.InternalSwap(&other->worker_beats_);
+  _internal_metadata_.Swap(&other->_internal_metadata_);
+  swap(_cached_size_, other->_cached_size_);
+}
+
+::google::protobuf::Metadata HeartbeatReq::GetMetadata() const {
   protobuf_tortuga_2ftortuga_2eproto::protobuf_AssignDescriptorsOnce();
   return ::protobuf_tortuga_2ftortuga_2eproto::file_level_metadata[kIndexInFileMessages];
 }

--- a/tortuga/tortuga.pb.h
+++ b/tortuga/tortuga.pb.h
@@ -42,7 +42,7 @@ namespace protobuf_tortuga_2ftortuga_2eproto {
 struct TableStruct {
   static const ::google::protobuf::internal::ParseTableField entries[];
   static const ::google::protobuf::internal::AuxillaryParseTableField aux[];
-  static const ::google::protobuf::internal::ParseTable schema[14];
+  static const ::google::protobuf::internal::ParseTable schema[15];
   static const ::google::protobuf::internal::FieldMetadata field_metadata[];
   static const ::google::protobuf::internal::SerializationTable serialization_table[];
   static const ::google::protobuf::uint32 offsets[];
@@ -50,8 +50,10 @@ struct TableStruct {
 void AddDescriptors();
 void InitDefaultsWorkerImpl();
 void InitDefaultsWorker();
-void InitDefaultsHeartbeatImpl();
-void InitDefaultsHeartbeat();
+void InitDefaultsHeartbeatReq_WorkerBeatImpl();
+void InitDefaultsHeartbeatReq_WorkerBeat();
+void InitDefaultsHeartbeatReqImpl();
+void InitDefaultsHeartbeatReq();
 void InitDefaultsTaskReqImpl();
 void InitDefaultsTaskReq();
 void InitDefaultsTaskResp_RetryContextImpl();
@@ -78,7 +80,8 @@ void InitDefaultsTaskIdentifierImpl();
 void InitDefaultsTaskIdentifier();
 inline void InitDefaults() {
   InitDefaultsWorker();
-  InitDefaultsHeartbeat();
+  InitDefaultsHeartbeatReq_WorkerBeat();
+  InitDefaultsHeartbeatReq();
   InitDefaultsTaskReq();
   InitDefaultsTaskResp_RetryContext();
   InitDefaultsTaskResp();
@@ -103,9 +106,12 @@ extern CreateReqDefaultTypeInternal _CreateReq_default_instance_;
 class CreateResp;
 class CreateRespDefaultTypeInternal;
 extern CreateRespDefaultTypeInternal _CreateResp_default_instance_;
-class Heartbeat;
-class HeartbeatDefaultTypeInternal;
-extern HeartbeatDefaultTypeInternal _Heartbeat_default_instance_;
+class HeartbeatReq;
+class HeartbeatReqDefaultTypeInternal;
+extern HeartbeatReqDefaultTypeInternal _HeartbeatReq_default_instance_;
+class HeartbeatReq_WorkerBeat;
+class HeartbeatReq_WorkerBeatDefaultTypeInternal;
+extern HeartbeatReq_WorkerBeatDefaultTypeInternal _HeartbeatReq_WorkerBeat_default_instance_;
 class ProgressReq;
 class ProgressReqDefaultTypeInternal;
 extern ProgressReqDefaultTypeInternal _ProgressReq_default_instance_;
@@ -286,24 +292,24 @@ class Worker : public ::google::protobuf::Message /* @@protoc_insertion_point(cl
 };
 // -------------------------------------------------------------------
 
-class Heartbeat : public ::google::protobuf::Message /* @@protoc_insertion_point(class_definition:tortuga.Heartbeat) */ {
+class HeartbeatReq_WorkerBeat : public ::google::protobuf::Message /* @@protoc_insertion_point(class_definition:tortuga.HeartbeatReq.WorkerBeat) */ {
  public:
-  Heartbeat();
-  virtual ~Heartbeat();
+  HeartbeatReq_WorkerBeat();
+  virtual ~HeartbeatReq_WorkerBeat();
 
-  Heartbeat(const Heartbeat& from);
+  HeartbeatReq_WorkerBeat(const HeartbeatReq_WorkerBeat& from);
 
-  inline Heartbeat& operator=(const Heartbeat& from) {
+  inline HeartbeatReq_WorkerBeat& operator=(const HeartbeatReq_WorkerBeat& from) {
     CopyFrom(from);
     return *this;
   }
   #if LANG_CXX11
-  Heartbeat(Heartbeat&& from) noexcept
-    : Heartbeat() {
+  HeartbeatReq_WorkerBeat(HeartbeatReq_WorkerBeat&& from) noexcept
+    : HeartbeatReq_WorkerBeat() {
     *this = ::std::move(from);
   }
 
-  inline Heartbeat& operator=(Heartbeat&& from) noexcept {
+  inline HeartbeatReq_WorkerBeat& operator=(HeartbeatReq_WorkerBeat&& from) noexcept {
     if (GetArenaNoVirtual() == from.GetArenaNoVirtual()) {
       if (this != &from) InternalSwap(&from);
     } else {
@@ -313,30 +319,30 @@ class Heartbeat : public ::google::protobuf::Message /* @@protoc_insertion_point
   }
   #endif
   static const ::google::protobuf::Descriptor* descriptor();
-  static const Heartbeat& default_instance();
+  static const HeartbeatReq_WorkerBeat& default_instance();
 
   static void InitAsDefaultInstance();  // FOR INTERNAL USE ONLY
-  static inline const Heartbeat* internal_default_instance() {
-    return reinterpret_cast<const Heartbeat*>(
-               &_Heartbeat_default_instance_);
+  static inline const HeartbeatReq_WorkerBeat* internal_default_instance() {
+    return reinterpret_cast<const HeartbeatReq_WorkerBeat*>(
+               &_HeartbeatReq_WorkerBeat_default_instance_);
   }
   static PROTOBUF_CONSTEXPR int const kIndexInFileMessages =
     1;
 
-  void Swap(Heartbeat* other);
-  friend void swap(Heartbeat& a, Heartbeat& b) {
+  void Swap(HeartbeatReq_WorkerBeat* other);
+  friend void swap(HeartbeatReq_WorkerBeat& a, HeartbeatReq_WorkerBeat& b) {
     a.Swap(&b);
   }
 
   // implements Message ----------------------------------------------
 
-  inline Heartbeat* New() const PROTOBUF_FINAL { return New(NULL); }
+  inline HeartbeatReq_WorkerBeat* New() const PROTOBUF_FINAL { return New(NULL); }
 
-  Heartbeat* New(::google::protobuf::Arena* arena) const PROTOBUF_FINAL;
+  HeartbeatReq_WorkerBeat* New(::google::protobuf::Arena* arena) const PROTOBUF_FINAL;
   void CopyFrom(const ::google::protobuf::Message& from) PROTOBUF_FINAL;
   void MergeFrom(const ::google::protobuf::Message& from) PROTOBUF_FINAL;
-  void CopyFrom(const Heartbeat& from);
-  void MergeFrom(const Heartbeat& from);
+  void CopyFrom(const HeartbeatReq_WorkerBeat& from);
+  void MergeFrom(const HeartbeatReq_WorkerBeat& from);
   void Clear() PROTOBUF_FINAL;
   bool IsInitialized() const PROTOBUF_FINAL;
 
@@ -352,7 +358,7 @@ class Heartbeat : public ::google::protobuf::Message /* @@protoc_insertion_point
   void SharedCtor();
   void SharedDtor();
   void SetCachedSize(int size) const PROTOBUF_FINAL;
-  void InternalSwap(Heartbeat* other);
+  void InternalSwap(HeartbeatReq_WorkerBeat* other);
   private:
   inline ::google::protobuf::Arena* GetArenaNoVirtual() const {
     return NULL;
@@ -389,7 +395,7 @@ class Heartbeat : public ::google::protobuf::Message /* @@protoc_insertion_point
   ::tortuga::Worker* mutable_worker();
   void set_allocated_worker(::tortuga::Worker* worker);
 
-  // @@protoc_insertion_point(class_scope:tortuga.Heartbeat)
+  // @@protoc_insertion_point(class_scope:tortuga.HeartbeatReq.WorkerBeat)
  private:
 
   ::google::protobuf::internal::InternalMetadataWithArena _internal_metadata_;
@@ -398,7 +404,114 @@ class Heartbeat : public ::google::protobuf::Message /* @@protoc_insertion_point
   ::tortuga::Worker* worker_;
   mutable int _cached_size_;
   friend struct ::protobuf_tortuga_2ftortuga_2eproto::TableStruct;
-  friend void ::protobuf_tortuga_2ftortuga_2eproto::InitDefaultsHeartbeatImpl();
+  friend void ::protobuf_tortuga_2ftortuga_2eproto::InitDefaultsHeartbeatReq_WorkerBeatImpl();
+};
+// -------------------------------------------------------------------
+
+class HeartbeatReq : public ::google::protobuf::Message /* @@protoc_insertion_point(class_definition:tortuga.HeartbeatReq) */ {
+ public:
+  HeartbeatReq();
+  virtual ~HeartbeatReq();
+
+  HeartbeatReq(const HeartbeatReq& from);
+
+  inline HeartbeatReq& operator=(const HeartbeatReq& from) {
+    CopyFrom(from);
+    return *this;
+  }
+  #if LANG_CXX11
+  HeartbeatReq(HeartbeatReq&& from) noexcept
+    : HeartbeatReq() {
+    *this = ::std::move(from);
+  }
+
+  inline HeartbeatReq& operator=(HeartbeatReq&& from) noexcept {
+    if (GetArenaNoVirtual() == from.GetArenaNoVirtual()) {
+      if (this != &from) InternalSwap(&from);
+    } else {
+      CopyFrom(from);
+    }
+    return *this;
+  }
+  #endif
+  static const ::google::protobuf::Descriptor* descriptor();
+  static const HeartbeatReq& default_instance();
+
+  static void InitAsDefaultInstance();  // FOR INTERNAL USE ONLY
+  static inline const HeartbeatReq* internal_default_instance() {
+    return reinterpret_cast<const HeartbeatReq*>(
+               &_HeartbeatReq_default_instance_);
+  }
+  static PROTOBUF_CONSTEXPR int const kIndexInFileMessages =
+    2;
+
+  void Swap(HeartbeatReq* other);
+  friend void swap(HeartbeatReq& a, HeartbeatReq& b) {
+    a.Swap(&b);
+  }
+
+  // implements Message ----------------------------------------------
+
+  inline HeartbeatReq* New() const PROTOBUF_FINAL { return New(NULL); }
+
+  HeartbeatReq* New(::google::protobuf::Arena* arena) const PROTOBUF_FINAL;
+  void CopyFrom(const ::google::protobuf::Message& from) PROTOBUF_FINAL;
+  void MergeFrom(const ::google::protobuf::Message& from) PROTOBUF_FINAL;
+  void CopyFrom(const HeartbeatReq& from);
+  void MergeFrom(const HeartbeatReq& from);
+  void Clear() PROTOBUF_FINAL;
+  bool IsInitialized() const PROTOBUF_FINAL;
+
+  size_t ByteSizeLong() const PROTOBUF_FINAL;
+  bool MergePartialFromCodedStream(
+      ::google::protobuf::io::CodedInputStream* input) PROTOBUF_FINAL;
+  void SerializeWithCachedSizes(
+      ::google::protobuf::io::CodedOutputStream* output) const PROTOBUF_FINAL;
+  ::google::protobuf::uint8* InternalSerializeWithCachedSizesToArray(
+      bool deterministic, ::google::protobuf::uint8* target) const PROTOBUF_FINAL;
+  int GetCachedSize() const PROTOBUF_FINAL { return _cached_size_; }
+  private:
+  void SharedCtor();
+  void SharedDtor();
+  void SetCachedSize(int size) const PROTOBUF_FINAL;
+  void InternalSwap(HeartbeatReq* other);
+  private:
+  inline ::google::protobuf::Arena* GetArenaNoVirtual() const {
+    return NULL;
+  }
+  inline void* MaybeArenaPtr() const {
+    return NULL;
+  }
+  public:
+
+  ::google::protobuf::Metadata GetMetadata() const PROTOBUF_FINAL;
+
+  // nested types ----------------------------------------------------
+
+  typedef HeartbeatReq_WorkerBeat WorkerBeat;
+
+  // accessors -------------------------------------------------------
+
+  // repeated .tortuga.HeartbeatReq.WorkerBeat worker_beats = 1;
+  int worker_beats_size() const;
+  void clear_worker_beats();
+  static const int kWorkerBeatsFieldNumber = 1;
+  const ::tortuga::HeartbeatReq_WorkerBeat& worker_beats(int index) const;
+  ::tortuga::HeartbeatReq_WorkerBeat* mutable_worker_beats(int index);
+  ::tortuga::HeartbeatReq_WorkerBeat* add_worker_beats();
+  ::google::protobuf::RepeatedPtrField< ::tortuga::HeartbeatReq_WorkerBeat >*
+      mutable_worker_beats();
+  const ::google::protobuf::RepeatedPtrField< ::tortuga::HeartbeatReq_WorkerBeat >&
+      worker_beats() const;
+
+  // @@protoc_insertion_point(class_scope:tortuga.HeartbeatReq)
+ private:
+
+  ::google::protobuf::internal::InternalMetadataWithArena _internal_metadata_;
+  ::google::protobuf::RepeatedPtrField< ::tortuga::HeartbeatReq_WorkerBeat > worker_beats_;
+  mutable int _cached_size_;
+  friend struct ::protobuf_tortuga_2ftortuga_2eproto::TableStruct;
+  friend void ::protobuf_tortuga_2ftortuga_2eproto::InitDefaultsHeartbeatReqImpl();
 };
 // -------------------------------------------------------------------
 
@@ -437,7 +550,7 @@ class TaskReq : public ::google::protobuf::Message /* @@protoc_insertion_point(c
                &_TaskReq_default_instance_);
   }
   static PROTOBUF_CONSTEXPR int const kIndexInFileMessages =
-    2;
+    3;
 
   void Swap(TaskReq* other);
   friend void swap(TaskReq& a, TaskReq& b) {
@@ -539,7 +652,7 @@ class TaskResp_RetryContext : public ::google::protobuf::Message /* @@protoc_ins
                &_TaskResp_RetryContext_default_instance_);
   }
   static PROTOBUF_CONSTEXPR int const kIndexInFileMessages =
-    3;
+    4;
 
   void Swap(TaskResp_RetryContext* other);
   friend void swap(TaskResp_RetryContext& a, TaskResp_RetryContext& b) {
@@ -653,7 +766,7 @@ class TaskResp : public ::google::protobuf::Message /* @@protoc_insertion_point(
                &_TaskResp_default_instance_);
   }
   static PROTOBUF_CONSTEXPR int const kIndexInFileMessages =
-    4;
+    5;
 
   void Swap(TaskResp* other);
   friend void swap(TaskResp& a, TaskResp& b) {
@@ -819,7 +932,7 @@ class Task : public ::google::protobuf::Message /* @@protoc_insertion_point(clas
                &_Task_default_instance_);
   }
   static PROTOBUF_CONSTEXPR int const kIndexInFileMessages =
-    5;
+    6;
 
   void Swap(Task* other);
   friend void swap(Task& a, Task& b) {
@@ -1004,7 +1117,7 @@ class TaskProgress : public ::google::protobuf::Message /* @@protoc_insertion_po
                &_TaskProgress_default_instance_);
   }
   static PROTOBUF_CONSTEXPR int const kIndexInFileMessages =
-    6;
+    7;
 
   void Swap(TaskProgress* other);
   friend void swap(TaskProgress& a, TaskProgress& b) {
@@ -1298,7 +1411,7 @@ class CreateReq : public ::google::protobuf::Message /* @@protoc_insertion_point
                &_CreateReq_default_instance_);
   }
   static PROTOBUF_CONSTEXPR int const kIndexInFileMessages =
-    7;
+    8;
 
   void Swap(CreateReq* other);
   friend void swap(CreateReq& a, CreateReq& b) {
@@ -1400,7 +1513,7 @@ class CreateResp : public ::google::protobuf::Message /* @@protoc_insertion_poin
                &_CreateResp_default_instance_);
   }
   static PROTOBUF_CONSTEXPR int const kIndexInFileMessages =
-    8;
+    9;
 
   void Swap(CreateResp* other);
   friend void swap(CreateResp& a, CreateResp& b) {
@@ -1514,7 +1627,7 @@ class CompleteTaskReq : public ::google::protobuf::Message /* @@protoc_insertion
                &_CompleteTaskReq_default_instance_);
   }
   static PROTOBUF_CONSTEXPR int const kIndexInFileMessages =
-    9;
+    10;
 
   void Swap(CompleteTaskReq* other);
   friend void swap(CompleteTaskReq& a, CompleteTaskReq& b) {
@@ -1683,7 +1796,7 @@ class UpdateProgressReq : public ::google::protobuf::Message /* @@protoc_inserti
                &_UpdateProgressReq_default_instance_);
   }
   static PROTOBUF_CONSTEXPR int const kIndexInFileMessages =
-    10;
+    11;
 
   void Swap(UpdateProgressReq* other);
   friend void swap(UpdateProgressReq& a, UpdateProgressReq& b) {
@@ -1830,7 +1943,7 @@ class ProgressReq : public ::google::protobuf::Message /* @@protoc_insertion_poi
                &_ProgressReq_default_instance_);
   }
   static PROTOBUF_CONSTEXPR int const kIndexInFileMessages =
-    11;
+    12;
 
   void Swap(ProgressReq* other);
   friend void swap(ProgressReq& a, ProgressReq& b) {
@@ -1937,7 +2050,7 @@ class ProgressResp : public ::google::protobuf::Message /* @@protoc_insertion_po
                &_ProgressResp_default_instance_);
   }
   static PROTOBUF_CONSTEXPR int const kIndexInFileMessages =
-    12;
+    13;
 
   void Swap(ProgressResp* other);
   friend void swap(ProgressResp& a, ProgressResp& b) {
@@ -2054,7 +2167,7 @@ class TaskIdentifier : public ::google::protobuf::Message /* @@protoc_insertion_
                &_TaskIdentifier_default_instance_);
   }
   static PROTOBUF_CONSTEXPR int const kIndexInFileMessages =
-    13;
+    14;
 
   void Swap(TaskIdentifier* other);
   friend void swap(TaskIdentifier& a, TaskIdentifier& b) {
@@ -2327,40 +2440,40 @@ Worker::mutable_capabilities() {
 
 // -------------------------------------------------------------------
 
-// Heartbeat
+// HeartbeatReq_WorkerBeat
 
 // .tortuga.Worker worker = 1;
-inline bool Heartbeat::has_worker() const {
+inline bool HeartbeatReq_WorkerBeat::has_worker() const {
   return this != internal_default_instance() && worker_ != NULL;
 }
-inline void Heartbeat::clear_worker() {
+inline void HeartbeatReq_WorkerBeat::clear_worker() {
   if (GetArenaNoVirtual() == NULL && worker_ != NULL) {
     delete worker_;
   }
   worker_ = NULL;
 }
-inline const ::tortuga::Worker& Heartbeat::worker() const {
+inline const ::tortuga::Worker& HeartbeatReq_WorkerBeat::worker() const {
   const ::tortuga::Worker* p = worker_;
-  // @@protoc_insertion_point(field_get:tortuga.Heartbeat.worker)
+  // @@protoc_insertion_point(field_get:tortuga.HeartbeatReq.WorkerBeat.worker)
   return p != NULL ? *p : *reinterpret_cast<const ::tortuga::Worker*>(
       &::tortuga::_Worker_default_instance_);
 }
-inline ::tortuga::Worker* Heartbeat::release_worker() {
-  // @@protoc_insertion_point(field_release:tortuga.Heartbeat.worker)
+inline ::tortuga::Worker* HeartbeatReq_WorkerBeat::release_worker() {
+  // @@protoc_insertion_point(field_release:tortuga.HeartbeatReq.WorkerBeat.worker)
   
   ::tortuga::Worker* temp = worker_;
   worker_ = NULL;
   return temp;
 }
-inline ::tortuga::Worker* Heartbeat::mutable_worker() {
+inline ::tortuga::Worker* HeartbeatReq_WorkerBeat::mutable_worker() {
   
   if (worker_ == NULL) {
     worker_ = new ::tortuga::Worker;
   }
-  // @@protoc_insertion_point(field_mutable:tortuga.Heartbeat.worker)
+  // @@protoc_insertion_point(field_mutable:tortuga.HeartbeatReq.WorkerBeat.worker)
   return worker_;
 }
-inline void Heartbeat::set_allocated_worker(::tortuga::Worker* worker) {
+inline void HeartbeatReq_WorkerBeat::set_allocated_worker(::tortuga::Worker* worker) {
   ::google::protobuf::Arena* message_arena = GetArenaNoVirtual();
   if (message_arena == NULL) {
     delete worker_;
@@ -2376,37 +2489,71 @@ inline void Heartbeat::set_allocated_worker(::tortuga::Worker* worker) {
     
   }
   worker_ = worker;
-  // @@protoc_insertion_point(field_set_allocated:tortuga.Heartbeat.worker)
+  // @@protoc_insertion_point(field_set_allocated:tortuga.HeartbeatReq.WorkerBeat.worker)
 }
 
 // repeated int64 current_task_handles = 2;
-inline int Heartbeat::current_task_handles_size() const {
+inline int HeartbeatReq_WorkerBeat::current_task_handles_size() const {
   return current_task_handles_.size();
 }
-inline void Heartbeat::clear_current_task_handles() {
+inline void HeartbeatReq_WorkerBeat::clear_current_task_handles() {
   current_task_handles_.Clear();
 }
-inline ::google::protobuf::int64 Heartbeat::current_task_handles(int index) const {
-  // @@protoc_insertion_point(field_get:tortuga.Heartbeat.current_task_handles)
+inline ::google::protobuf::int64 HeartbeatReq_WorkerBeat::current_task_handles(int index) const {
+  // @@protoc_insertion_point(field_get:tortuga.HeartbeatReq.WorkerBeat.current_task_handles)
   return current_task_handles_.Get(index);
 }
-inline void Heartbeat::set_current_task_handles(int index, ::google::protobuf::int64 value) {
+inline void HeartbeatReq_WorkerBeat::set_current_task_handles(int index, ::google::protobuf::int64 value) {
   current_task_handles_.Set(index, value);
-  // @@protoc_insertion_point(field_set:tortuga.Heartbeat.current_task_handles)
+  // @@protoc_insertion_point(field_set:tortuga.HeartbeatReq.WorkerBeat.current_task_handles)
 }
-inline void Heartbeat::add_current_task_handles(::google::protobuf::int64 value) {
+inline void HeartbeatReq_WorkerBeat::add_current_task_handles(::google::protobuf::int64 value) {
   current_task_handles_.Add(value);
-  // @@protoc_insertion_point(field_add:tortuga.Heartbeat.current_task_handles)
+  // @@protoc_insertion_point(field_add:tortuga.HeartbeatReq.WorkerBeat.current_task_handles)
 }
 inline const ::google::protobuf::RepeatedField< ::google::protobuf::int64 >&
-Heartbeat::current_task_handles() const {
-  // @@protoc_insertion_point(field_list:tortuga.Heartbeat.current_task_handles)
+HeartbeatReq_WorkerBeat::current_task_handles() const {
+  // @@protoc_insertion_point(field_list:tortuga.HeartbeatReq.WorkerBeat.current_task_handles)
   return current_task_handles_;
 }
 inline ::google::protobuf::RepeatedField< ::google::protobuf::int64 >*
-Heartbeat::mutable_current_task_handles() {
-  // @@protoc_insertion_point(field_mutable_list:tortuga.Heartbeat.current_task_handles)
+HeartbeatReq_WorkerBeat::mutable_current_task_handles() {
+  // @@protoc_insertion_point(field_mutable_list:tortuga.HeartbeatReq.WorkerBeat.current_task_handles)
   return &current_task_handles_;
+}
+
+// -------------------------------------------------------------------
+
+// HeartbeatReq
+
+// repeated .tortuga.HeartbeatReq.WorkerBeat worker_beats = 1;
+inline int HeartbeatReq::worker_beats_size() const {
+  return worker_beats_.size();
+}
+inline void HeartbeatReq::clear_worker_beats() {
+  worker_beats_.Clear();
+}
+inline const ::tortuga::HeartbeatReq_WorkerBeat& HeartbeatReq::worker_beats(int index) const {
+  // @@protoc_insertion_point(field_get:tortuga.HeartbeatReq.worker_beats)
+  return worker_beats_.Get(index);
+}
+inline ::tortuga::HeartbeatReq_WorkerBeat* HeartbeatReq::mutable_worker_beats(int index) {
+  // @@protoc_insertion_point(field_mutable:tortuga.HeartbeatReq.worker_beats)
+  return worker_beats_.Mutable(index);
+}
+inline ::tortuga::HeartbeatReq_WorkerBeat* HeartbeatReq::add_worker_beats() {
+  // @@protoc_insertion_point(field_add:tortuga.HeartbeatReq.worker_beats)
+  return worker_beats_.Add();
+}
+inline ::google::protobuf::RepeatedPtrField< ::tortuga::HeartbeatReq_WorkerBeat >*
+HeartbeatReq::mutable_worker_beats() {
+  // @@protoc_insertion_point(field_mutable_list:tortuga.HeartbeatReq.worker_beats)
+  return &worker_beats_;
+}
+inline const ::google::protobuf::RepeatedPtrField< ::tortuga::HeartbeatReq_WorkerBeat >&
+HeartbeatReq::worker_beats() const {
+  // @@protoc_insertion_point(field_list:tortuga.HeartbeatReq.worker_beats)
+  return worker_beats_;
 }
 
 // -------------------------------------------------------------------
@@ -4772,6 +4919,8 @@ inline void TaskIdentifier::set_allocated_type(::std::string* type) {
 #ifdef __GNUC__
   #pragma GCC diagnostic pop
 #endif  // __GNUC__
+// -------------------------------------------------------------------
+
 // -------------------------------------------------------------------
 
 // -------------------------------------------------------------------

--- a/tortuga/tortuga.proto
+++ b/tortuga/tortuga.proto
@@ -21,11 +21,17 @@ message Worker {
   repeated string capabilities = 3;
 }
 
-message Heartbeat {
-  Worker worker = 1;
+message HeartbeatReq {
+  // a connection handling multiple workers will beat for all of them at once
+  // hence this is repeated.
+  message WorkerBeat {
+    Worker worker = 1;
 
-  // They must be sorted!
-  repeated int64 current_task_handles = 2;
+    // They must be sorted!
+    repeated int64 current_task_handles = 2;
+  }
+
+  repeated WorkerBeat worker_beats = 1;
 }
 
 message TaskReq {
@@ -139,7 +145,7 @@ message TaskIdentifier {
 service Tortuga {
   rpc CreateTask(CreateReq) returns (CreateResp);
   rpc RequestTask(TaskReq) returns (TaskResp);
-  rpc Heartbeat(Worker) returns (google.protobuf.Empty);
+  rpc Heartbeat(HeartbeatReq) returns (google.protobuf.Empty);
   rpc CompleteTask(CompleteTaskReq) returns (google.protobuf.Empty);
   rpc UpdateProgress(UpdateProgressReq) returns (google.protobuf.Empty);
 


### PR DESCRIPTION
Heartbeats improvements: only one call per connection, batching all the workers together.
Only one heartbeat req may be issued at a time otherwise we can flood the server.