### PR TITLE
GRPC bridge support for setting the task output.

### DIFF
--- a/src/generated/java/io/tortuga/test/TestService2Grpc.java
+++ b/src/generated/java/io/tortuga/test/TestService2Grpc.java
@@ -55,16 +55,16 @@ public final class TestService2Grpc {
   }
 
   private static volatile io.grpc.MethodDescriptor<io.tortuga.test.TortugaProto.TestMessage,
-      com.google.protobuf.Empty> getHandleCustomMessage2Method;
+      io.tortuga.TortugaParamsProto.TortugaOutput> getHandleCustomMessage2Method;
 
   public static io.grpc.MethodDescriptor<io.tortuga.test.TortugaProto.TestMessage,
-      com.google.protobuf.Empty> getHandleCustomMessage2Method() {
-    io.grpc.MethodDescriptor<io.tortuga.test.TortugaProto.TestMessage, com.google.protobuf.Empty> getHandleCustomMessage2Method;
+      io.tortuga.TortugaParamsProto.TortugaOutput> getHandleCustomMessage2Method() {
+    io.grpc.MethodDescriptor<io.tortuga.test.TortugaProto.TestMessage, io.tortuga.TortugaParamsProto.TortugaOutput> getHandleCustomMessage2Method;
     if ((getHandleCustomMessage2Method = TestService2Grpc.getHandleCustomMessage2Method) == null) {
       synchronized (TestService2Grpc.class) {
         if ((getHandleCustomMessage2Method = TestService2Grpc.getHandleCustomMessage2Method) == null) {
           TestService2Grpc.getHandleCustomMessage2Method = getHandleCustomMessage2Method = 
-              io.grpc.MethodDescriptor.<io.tortuga.test.TortugaProto.TestMessage, com.google.protobuf.Empty>newBuilder()
+              io.grpc.MethodDescriptor.<io.tortuga.test.TortugaProto.TestMessage, io.tortuga.TortugaParamsProto.TortugaOutput>newBuilder()
               .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
               .setFullMethodName(generateFullMethodName(
                   "tortuga.test.TestService2", "HandleCustomMessage2"))
@@ -72,7 +72,7 @@ public final class TestService2Grpc {
               .setRequestMarshaller(io.grpc.protobuf.ProtoUtils.marshaller(
                   io.tortuga.test.TortugaProto.TestMessage.getDefaultInstance()))
               .setResponseMarshaller(io.grpc.protobuf.ProtoUtils.marshaller(
-                  com.google.protobuf.Empty.getDefaultInstance()))
+                  io.tortuga.TortugaParamsProto.TortugaOutput.getDefaultInstance()))
                   .setSchemaDescriptor(new TestService2MethodDescriptorSupplier("HandleCustomMessage2"))
                   .build();
           }
@@ -118,7 +118,7 @@ public final class TestService2Grpc {
     /**
      */
     public void handleCustomMessage2(io.tortuga.test.TortugaProto.TestMessage request,
-        io.grpc.stub.StreamObserver<com.google.protobuf.Empty> responseObserver) {
+        io.grpc.stub.StreamObserver<io.tortuga.TortugaParamsProto.TortugaOutput> responseObserver) {
       asyncUnimplementedUnaryCall(getHandleCustomMessage2Method(), responseObserver);
     }
 
@@ -136,7 +136,7 @@ public final class TestService2Grpc {
             asyncUnaryCall(
               new MethodHandlers<
                 io.tortuga.test.TortugaProto.TestMessage,
-                com.google.protobuf.Empty>(
+                io.tortuga.TortugaParamsProto.TortugaOutput>(
                   this, METHODID_HANDLE_CUSTOM_MESSAGE2)))
           .build();
     }
@@ -171,7 +171,7 @@ public final class TestService2Grpc {
     /**
      */
     public void handleCustomMessage2(io.tortuga.test.TortugaProto.TestMessage request,
-        io.grpc.stub.StreamObserver<com.google.protobuf.Empty> responseObserver) {
+        io.grpc.stub.StreamObserver<io.tortuga.TortugaParamsProto.TortugaOutput> responseObserver) {
       asyncUnaryCall(
           getChannel().newCall(getHandleCustomMessage2Method(), getCallOptions()), request, responseObserver);
     }
@@ -204,7 +204,7 @@ public final class TestService2Grpc {
 
     /**
      */
-    public com.google.protobuf.Empty handleCustomMessage2(io.tortuga.test.TortugaProto.TestMessage request) {
+    public io.tortuga.TortugaParamsProto.TortugaOutput handleCustomMessage2(io.tortuga.test.TortugaProto.TestMessage request) {
       return blockingUnaryCall(
           getChannel(), getHandleCustomMessage2Method(), getCallOptions(), request);
     }
@@ -238,7 +238,7 @@ public final class TestService2Grpc {
 
     /**
      */
-    public com.google.common.util.concurrent.ListenableFuture<com.google.protobuf.Empty> handleCustomMessage2(
+    public com.google.common.util.concurrent.ListenableFuture<io.tortuga.TortugaParamsProto.TortugaOutput> handleCustomMessage2(
         io.tortuga.test.TortugaProto.TestMessage request) {
       return futureUnaryCall(
           getChannel().newCall(getHandleCustomMessage2Method(), getCallOptions()), request);
@@ -271,7 +271,7 @@ public final class TestService2Grpc {
           break;
         case METHODID_HANDLE_CUSTOM_MESSAGE2:
           serviceImpl.handleCustomMessage2((io.tortuga.test.TortugaProto.TestMessage) request,
-              (io.grpc.stub.StreamObserver<com.google.protobuf.Empty>) responseObserver);
+              (io.grpc.stub.StreamObserver<io.tortuga.TortugaParamsProto.TortugaOutput>) responseObserver);
           break;
         default:
           throw new AssertionError();

--- a/src/generated/java/io/tortuga/test/TestService2Tortuga.java
+++ b/src/generated/java/io/tortuga/test/TestService2Tortuga.java
@@ -90,7 +90,8 @@ public class TestService2Tortuga {
       io.tortuga.test.TestService2Grpc.TestService2BlockingStub stub = io.tortuga.test.TestService2Grpc.newBlockingStub(this.chan);
       stub = stub.withDeadlineAfter(30, TimeUnit.SECONDS);
       try {
-        stub.handleCustomMessage2(t);
+        io.tortuga.TortugaParamsProto.TortugaOutput output = stub.handleCustomMessage2(t);
+        ctx.setOutput(output.getOutput());
         return Futures.immediateFuture(Status.OK);
       } catch (StatusRuntimeException ex) {
         return Futures.immediateFuture(ex.getStatus());

--- a/src/generated/java/io/tortuga/test/TortugaProto.java
+++ b/src/generated/java/io/tortuga/test/TortugaProto.java
@@ -555,17 +555,17 @@ public final class TortugaProto {
     java.lang.String[] descriptorData = {
       "\n\022tortuga/test.proto\022\014tortuga.test\032\033goog" +
       "le/protobuf/empty.proto\032\036google/protobuf" +
-      "/wrappers.proto\"\031\n\013TestMessage\022\n\n\002id\030\001 \001" +
-      "(\t2\233\001\n\013TestService\022B\n\nHandleTask\022\034.googl" +
-      "e.protobuf.StringValue\032\026.google.protobuf" +
-      ".Empty\022H\n\023HandleCustomMessage\022\031.tortuga." +
-      "test.TestMessage\032\026.google.protobuf.Empty" +
-      "2\236\001\n\014TestService2\022C\n\013HandleTask2\022\034.googl" +
-      "e.protobuf.StringValue\032\026.google.protobuf" +
-      ".Empty\022I\n\024HandleCustomMessage2\022\031.tortuga" +
-      ".test.TestMessage\032\026.google.protobuf.Empt" +
-      "yB\037\n\017io.tortuga.testB\014TortugaProtob\006prot" +
-      "o3"
+      "/wrappers.proto\032\034tortuga/tortuga_params." +
+      "proto\"\031\n\013TestMessage\022\n\n\002id\030\001 \001(\t2\233\001\n\013Tes" +
+      "tService\022B\n\nHandleTask\022\034.google.protobuf" +
+      ".StringValue\032\026.google.protobuf.Empty\022H\n\023" +
+      "HandleCustomMessage\022\031.tortuga.test.TestM" +
+      "essage\032\026.google.protobuf.Empty2\236\001\n\014TestS" +
+      "ervice2\022C\n\013HandleTask2\022\034.google.protobuf" +
+      ".StringValue\032\026.google.protobuf.Empty\022I\n\024" +
+      "HandleCustomMessage2\022\031.tortuga.test.Test" +
+      "Message\032\026.tortuga.TortugaOutputB\037\n\017io.to" +
+      "rtuga.testB\014TortugaProtob\006proto3"
     };
     com.google.protobuf.Descriptors.FileDescriptor.InternalDescriptorAssigner assigner =
         new com.google.protobuf.Descriptors.FileDescriptor.    InternalDescriptorAssigner() {
@@ -580,6 +580,7 @@ public final class TortugaProto {
         new com.google.protobuf.Descriptors.FileDescriptor[] {
           com.google.protobuf.EmptyProto.getDescriptor(),
           com.google.protobuf.WrappersProto.getDescriptor(),
+          io.tortuga.TortugaParamsProto.getDescriptor(),
         }, assigner);
     internal_static_tortuga_test_TestMessage_descriptor =
       getDescriptor().getMessageTypes().get(0);
@@ -589,6 +590,7 @@ public final class TortugaProto {
         new java.lang.String[] { "Id", });
     com.google.protobuf.EmptyProto.getDescriptor();
     com.google.protobuf.WrappersProto.getDescriptor();
+    io.tortuga.TortugaParamsProto.getDescriptor();
   }
 
   // @@protoc_insertion_point(outer_class_scope)

--- a/src/main/java/io/tortuga/TortugaParamsProto.java
+++ b/src/main/java/io/tortuga/TortugaParamsProto.java
@@ -495,6 +495,576 @@ public final class TortugaParamsProto {
 
   }
 
+  public interface TortugaOutputOrBuilder extends
+      // @@protoc_insertion_point(interface_extends:tortuga.TortugaOutput)
+      com.google.protobuf.MessageOrBuilder {
+
+    /**
+     * <code>optional string output = 1;</code>
+     */
+    boolean hasOutput();
+    /**
+     * <code>optional string output = 1;</code>
+     */
+    java.lang.String getOutput();
+    /**
+     * <code>optional string output = 1;</code>
+     */
+    com.google.protobuf.ByteString
+        getOutputBytes();
+  }
+  /**
+   * <pre>
+   * This message is to be used by tortuga &lt;&gt; GRPR bridge.
+   * If and only if the service returns this Type, and 'output' is not empty, then the
+   * tortuga bridge will write this as output of the task.
+   * </pre>
+   *
+   * Protobuf type {@code tortuga.TortugaOutput}
+   */
+  public  static final class TortugaOutput extends
+      com.google.protobuf.GeneratedMessageV3 implements
+      // @@protoc_insertion_point(message_implements:tortuga.TortugaOutput)
+      TortugaOutputOrBuilder {
+  private static final long serialVersionUID = 0L;
+    // Use TortugaOutput.newBuilder() to construct.
+    private TortugaOutput(com.google.protobuf.GeneratedMessageV3.Builder<?> builder) {
+      super(builder);
+    }
+    private TortugaOutput() {
+      output_ = "";
+    }
+
+    @java.lang.Override
+    public final com.google.protobuf.UnknownFieldSet
+    getUnknownFields() {
+      return this.unknownFields;
+    }
+    private TortugaOutput(
+        com.google.protobuf.CodedInputStream input,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      this();
+      if (extensionRegistry == null) {
+        throw new java.lang.NullPointerException();
+      }
+      int mutable_bitField0_ = 0;
+      com.google.protobuf.UnknownFieldSet.Builder unknownFields =
+          com.google.protobuf.UnknownFieldSet.newBuilder();
+      try {
+        boolean done = false;
+        while (!done) {
+          int tag = input.readTag();
+          switch (tag) {
+            case 0:
+              done = true;
+              break;
+            default: {
+              if (!parseUnknownField(
+                  input, unknownFields, extensionRegistry, tag)) {
+                done = true;
+              }
+              break;
+            }
+            case 10: {
+              com.google.protobuf.ByteString bs = input.readBytes();
+              bitField0_ |= 0x00000001;
+              output_ = bs;
+              break;
+            }
+          }
+        }
+      } catch (com.google.protobuf.InvalidProtocolBufferException e) {
+        throw e.setUnfinishedMessage(this);
+      } catch (java.io.IOException e) {
+        throw new com.google.protobuf.InvalidProtocolBufferException(
+            e).setUnfinishedMessage(this);
+      } finally {
+        this.unknownFields = unknownFields.build();
+        makeExtensionsImmutable();
+      }
+    }
+    public static final com.google.protobuf.Descriptors.Descriptor
+        getDescriptor() {
+      return io.tortuga.TortugaParamsProto.internal_static_tortuga_TortugaOutput_descriptor;
+    }
+
+    protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
+        internalGetFieldAccessorTable() {
+      return io.tortuga.TortugaParamsProto.internal_static_tortuga_TortugaOutput_fieldAccessorTable
+          .ensureFieldAccessorsInitialized(
+              io.tortuga.TortugaParamsProto.TortugaOutput.class, io.tortuga.TortugaParamsProto.TortugaOutput.Builder.class);
+    }
+
+    private int bitField0_;
+    public static final int OUTPUT_FIELD_NUMBER = 1;
+    private volatile java.lang.Object output_;
+    /**
+     * <code>optional string output = 1;</code>
+     */
+    public boolean hasOutput() {
+      return ((bitField0_ & 0x00000001) == 0x00000001);
+    }
+    /**
+     * <code>optional string output = 1;</code>
+     */
+    public java.lang.String getOutput() {
+      java.lang.Object ref = output_;
+      if (ref instanceof java.lang.String) {
+        return (java.lang.String) ref;
+      } else {
+        com.google.protobuf.ByteString bs = 
+            (com.google.protobuf.ByteString) ref;
+        java.lang.String s = bs.toStringUtf8();
+        if (bs.isValidUtf8()) {
+          output_ = s;
+        }
+        return s;
+      }
+    }
+    /**
+     * <code>optional string output = 1;</code>
+     */
+    public com.google.protobuf.ByteString
+        getOutputBytes() {
+      java.lang.Object ref = output_;
+      if (ref instanceof java.lang.String) {
+        com.google.protobuf.ByteString b = 
+            com.google.protobuf.ByteString.copyFromUtf8(
+                (java.lang.String) ref);
+        output_ = b;
+        return b;
+      } else {
+        return (com.google.protobuf.ByteString) ref;
+      }
+    }
+
+    private byte memoizedIsInitialized = -1;
+    public final boolean isInitialized() {
+      byte isInitialized = memoizedIsInitialized;
+      if (isInitialized == 1) return true;
+      if (isInitialized == 0) return false;
+
+      memoizedIsInitialized = 1;
+      return true;
+    }
+
+    public void writeTo(com.google.protobuf.CodedOutputStream output)
+                        throws java.io.IOException {
+      if (((bitField0_ & 0x00000001) == 0x00000001)) {
+        com.google.protobuf.GeneratedMessageV3.writeString(output, 1, output_);
+      }
+      unknownFields.writeTo(output);
+    }
+
+    public int getSerializedSize() {
+      int size = memoizedSize;
+      if (size != -1) return size;
+
+      size = 0;
+      if (((bitField0_ & 0x00000001) == 0x00000001)) {
+        size += com.google.protobuf.GeneratedMessageV3.computeStringSize(1, output_);
+      }
+      size += unknownFields.getSerializedSize();
+      memoizedSize = size;
+      return size;
+    }
+
+    @java.lang.Override
+    public boolean equals(final java.lang.Object obj) {
+      if (obj == this) {
+       return true;
+      }
+      if (!(obj instanceof io.tortuga.TortugaParamsProto.TortugaOutput)) {
+        return super.equals(obj);
+      }
+      io.tortuga.TortugaParamsProto.TortugaOutput other = (io.tortuga.TortugaParamsProto.TortugaOutput) obj;
+
+      boolean result = true;
+      result = result && (hasOutput() == other.hasOutput());
+      if (hasOutput()) {
+        result = result && getOutput()
+            .equals(other.getOutput());
+      }
+      result = result && unknownFields.equals(other.unknownFields);
+      return result;
+    }
+
+    @java.lang.Override
+    public int hashCode() {
+      if (memoizedHashCode != 0) {
+        return memoizedHashCode;
+      }
+      int hash = 41;
+      hash = (19 * hash) + getDescriptor().hashCode();
+      if (hasOutput()) {
+        hash = (37 * hash) + OUTPUT_FIELD_NUMBER;
+        hash = (53 * hash) + getOutput().hashCode();
+      }
+      hash = (29 * hash) + unknownFields.hashCode();
+      memoizedHashCode = hash;
+      return hash;
+    }
+
+    public static io.tortuga.TortugaParamsProto.TortugaOutput parseFrom(
+        java.nio.ByteBuffer data)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data);
+    }
+    public static io.tortuga.TortugaParamsProto.TortugaOutput parseFrom(
+        java.nio.ByteBuffer data,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data, extensionRegistry);
+    }
+    public static io.tortuga.TortugaParamsProto.TortugaOutput parseFrom(
+        com.google.protobuf.ByteString data)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data);
+    }
+    public static io.tortuga.TortugaParamsProto.TortugaOutput parseFrom(
+        com.google.protobuf.ByteString data,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data, extensionRegistry);
+    }
+    public static io.tortuga.TortugaParamsProto.TortugaOutput parseFrom(byte[] data)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data);
+    }
+    public static io.tortuga.TortugaParamsProto.TortugaOutput parseFrom(
+        byte[] data,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data, extensionRegistry);
+    }
+    public static io.tortuga.TortugaParamsProto.TortugaOutput parseFrom(java.io.InputStream input)
+        throws java.io.IOException {
+      return com.google.protobuf.GeneratedMessageV3
+          .parseWithIOException(PARSER, input);
+    }
+    public static io.tortuga.TortugaParamsProto.TortugaOutput parseFrom(
+        java.io.InputStream input,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws java.io.IOException {
+      return com.google.protobuf.GeneratedMessageV3
+          .parseWithIOException(PARSER, input, extensionRegistry);
+    }
+    public static io.tortuga.TortugaParamsProto.TortugaOutput parseDelimitedFrom(java.io.InputStream input)
+        throws java.io.IOException {
+      return com.google.protobuf.GeneratedMessageV3
+          .parseDelimitedWithIOException(PARSER, input);
+    }
+    public static io.tortuga.TortugaParamsProto.TortugaOutput parseDelimitedFrom(
+        java.io.InputStream input,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws java.io.IOException {
+      return com.google.protobuf.GeneratedMessageV3
+          .parseDelimitedWithIOException(PARSER, input, extensionRegistry);
+    }
+    public static io.tortuga.TortugaParamsProto.TortugaOutput parseFrom(
+        com.google.protobuf.CodedInputStream input)
+        throws java.io.IOException {
+      return com.google.protobuf.GeneratedMessageV3
+          .parseWithIOException(PARSER, input);
+    }
+    public static io.tortuga.TortugaParamsProto.TortugaOutput parseFrom(
+        com.google.protobuf.CodedInputStream input,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws java.io.IOException {
+      return com.google.protobuf.GeneratedMessageV3
+          .parseWithIOException(PARSER, input, extensionRegistry);
+    }
+
+    public Builder newBuilderForType() { return newBuilder(); }
+    public static Builder newBuilder() {
+      return DEFAULT_INSTANCE.toBuilder();
+    }
+    public static Builder newBuilder(io.tortuga.TortugaParamsProto.TortugaOutput prototype) {
+      return DEFAULT_INSTANCE.toBuilder().mergeFrom(prototype);
+    }
+    public Builder toBuilder() {
+      return this == DEFAULT_INSTANCE
+          ? new Builder() : new Builder().mergeFrom(this);
+    }
+
+    @java.lang.Override
+    protected Builder newBuilderForType(
+        com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
+      Builder builder = new Builder(parent);
+      return builder;
+    }
+    /**
+     * <pre>
+     * This message is to be used by tortuga &lt;&gt; GRPR bridge.
+     * If and only if the service returns this Type, and 'output' is not empty, then the
+     * tortuga bridge will write this as output of the task.
+     * </pre>
+     *
+     * Protobuf type {@code tortuga.TortugaOutput}
+     */
+    public static final class Builder extends
+        com.google.protobuf.GeneratedMessageV3.Builder<Builder> implements
+        // @@protoc_insertion_point(builder_implements:tortuga.TortugaOutput)
+        io.tortuga.TortugaParamsProto.TortugaOutputOrBuilder {
+      public static final com.google.protobuf.Descriptors.Descriptor
+          getDescriptor() {
+        return io.tortuga.TortugaParamsProto.internal_static_tortuga_TortugaOutput_descriptor;
+      }
+
+      protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
+          internalGetFieldAccessorTable() {
+        return io.tortuga.TortugaParamsProto.internal_static_tortuga_TortugaOutput_fieldAccessorTable
+            .ensureFieldAccessorsInitialized(
+                io.tortuga.TortugaParamsProto.TortugaOutput.class, io.tortuga.TortugaParamsProto.TortugaOutput.Builder.class);
+      }
+
+      // Construct using io.tortuga.TortugaParamsProto.TortugaOutput.newBuilder()
+      private Builder() {
+        maybeForceBuilderInitialization();
+      }
+
+      private Builder(
+          com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
+        super(parent);
+        maybeForceBuilderInitialization();
+      }
+      private void maybeForceBuilderInitialization() {
+        if (com.google.protobuf.GeneratedMessageV3
+                .alwaysUseFieldBuilders) {
+        }
+      }
+      public Builder clear() {
+        super.clear();
+        output_ = "";
+        bitField0_ = (bitField0_ & ~0x00000001);
+        return this;
+      }
+
+      public com.google.protobuf.Descriptors.Descriptor
+          getDescriptorForType() {
+        return io.tortuga.TortugaParamsProto.internal_static_tortuga_TortugaOutput_descriptor;
+      }
+
+      public io.tortuga.TortugaParamsProto.TortugaOutput getDefaultInstanceForType() {
+        return io.tortuga.TortugaParamsProto.TortugaOutput.getDefaultInstance();
+      }
+
+      public io.tortuga.TortugaParamsProto.TortugaOutput build() {
+        io.tortuga.TortugaParamsProto.TortugaOutput result = buildPartial();
+        if (!result.isInitialized()) {
+          throw newUninitializedMessageException(result);
+        }
+        return result;
+      }
+
+      public io.tortuga.TortugaParamsProto.TortugaOutput buildPartial() {
+        io.tortuga.TortugaParamsProto.TortugaOutput result = new io.tortuga.TortugaParamsProto.TortugaOutput(this);
+        int from_bitField0_ = bitField0_;
+        int to_bitField0_ = 0;
+        if (((from_bitField0_ & 0x00000001) == 0x00000001)) {
+          to_bitField0_ |= 0x00000001;
+        }
+        result.output_ = output_;
+        result.bitField0_ = to_bitField0_;
+        onBuilt();
+        return result;
+      }
+
+      public Builder clone() {
+        return (Builder) super.clone();
+      }
+      public Builder setField(
+          com.google.protobuf.Descriptors.FieldDescriptor field,
+          java.lang.Object value) {
+        return (Builder) super.setField(field, value);
+      }
+      public Builder clearField(
+          com.google.protobuf.Descriptors.FieldDescriptor field) {
+        return (Builder) super.clearField(field);
+      }
+      public Builder clearOneof(
+          com.google.protobuf.Descriptors.OneofDescriptor oneof) {
+        return (Builder) super.clearOneof(oneof);
+      }
+      public Builder setRepeatedField(
+          com.google.protobuf.Descriptors.FieldDescriptor field,
+          int index, java.lang.Object value) {
+        return (Builder) super.setRepeatedField(field, index, value);
+      }
+      public Builder addRepeatedField(
+          com.google.protobuf.Descriptors.FieldDescriptor field,
+          java.lang.Object value) {
+        return (Builder) super.addRepeatedField(field, value);
+      }
+      public Builder mergeFrom(com.google.protobuf.Message other) {
+        if (other instanceof io.tortuga.TortugaParamsProto.TortugaOutput) {
+          return mergeFrom((io.tortuga.TortugaParamsProto.TortugaOutput)other);
+        } else {
+          super.mergeFrom(other);
+          return this;
+        }
+      }
+
+      public Builder mergeFrom(io.tortuga.TortugaParamsProto.TortugaOutput other) {
+        if (other == io.tortuga.TortugaParamsProto.TortugaOutput.getDefaultInstance()) return this;
+        if (other.hasOutput()) {
+          bitField0_ |= 0x00000001;
+          output_ = other.output_;
+          onChanged();
+        }
+        this.mergeUnknownFields(other.unknownFields);
+        onChanged();
+        return this;
+      }
+
+      public final boolean isInitialized() {
+        return true;
+      }
+
+      public Builder mergeFrom(
+          com.google.protobuf.CodedInputStream input,
+          com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+          throws java.io.IOException {
+        io.tortuga.TortugaParamsProto.TortugaOutput parsedMessage = null;
+        try {
+          parsedMessage = PARSER.parsePartialFrom(input, extensionRegistry);
+        } catch (com.google.protobuf.InvalidProtocolBufferException e) {
+          parsedMessage = (io.tortuga.TortugaParamsProto.TortugaOutput) e.getUnfinishedMessage();
+          throw e.unwrapIOException();
+        } finally {
+          if (parsedMessage != null) {
+            mergeFrom(parsedMessage);
+          }
+        }
+        return this;
+      }
+      private int bitField0_;
+
+      private java.lang.Object output_ = "";
+      /**
+       * <code>optional string output = 1;</code>
+       */
+      public boolean hasOutput() {
+        return ((bitField0_ & 0x00000001) == 0x00000001);
+      }
+      /**
+       * <code>optional string output = 1;</code>
+       */
+      public java.lang.String getOutput() {
+        java.lang.Object ref = output_;
+        if (!(ref instanceof java.lang.String)) {
+          com.google.protobuf.ByteString bs =
+              (com.google.protobuf.ByteString) ref;
+          java.lang.String s = bs.toStringUtf8();
+          if (bs.isValidUtf8()) {
+            output_ = s;
+          }
+          return s;
+        } else {
+          return (java.lang.String) ref;
+        }
+      }
+      /**
+       * <code>optional string output = 1;</code>
+       */
+      public com.google.protobuf.ByteString
+          getOutputBytes() {
+        java.lang.Object ref = output_;
+        if (ref instanceof String) {
+          com.google.protobuf.ByteString b = 
+              com.google.protobuf.ByteString.copyFromUtf8(
+                  (java.lang.String) ref);
+          output_ = b;
+          return b;
+        } else {
+          return (com.google.protobuf.ByteString) ref;
+        }
+      }
+      /**
+       * <code>optional string output = 1;</code>
+       */
+      public Builder setOutput(
+          java.lang.String value) {
+        if (value == null) {
+    throw new NullPointerException();
+  }
+  bitField0_ |= 0x00000001;
+        output_ = value;
+        onChanged();
+        return this;
+      }
+      /**
+       * <code>optional string output = 1;</code>
+       */
+      public Builder clearOutput() {
+        bitField0_ = (bitField0_ & ~0x00000001);
+        output_ = getDefaultInstance().getOutput();
+        onChanged();
+        return this;
+      }
+      /**
+       * <code>optional string output = 1;</code>
+       */
+      public Builder setOutputBytes(
+          com.google.protobuf.ByteString value) {
+        if (value == null) {
+    throw new NullPointerException();
+  }
+  bitField0_ |= 0x00000001;
+        output_ = value;
+        onChanged();
+        return this;
+      }
+      public final Builder setUnknownFields(
+          final com.google.protobuf.UnknownFieldSet unknownFields) {
+        return super.setUnknownFields(unknownFields);
+      }
+
+      public final Builder mergeUnknownFields(
+          final com.google.protobuf.UnknownFieldSet unknownFields) {
+        return super.mergeUnknownFields(unknownFields);
+      }
+
+
+      // @@protoc_insertion_point(builder_scope:tortuga.TortugaOutput)
+    }
+
+    // @@protoc_insertion_point(class_scope:tortuga.TortugaOutput)
+    private static final io.tortuga.TortugaParamsProto.TortugaOutput DEFAULT_INSTANCE;
+    static {
+      DEFAULT_INSTANCE = new io.tortuga.TortugaParamsProto.TortugaOutput();
+    }
+
+    public static io.tortuga.TortugaParamsProto.TortugaOutput getDefaultInstance() {
+      return DEFAULT_INSTANCE;
+    }
+
+    @java.lang.Deprecated public static final com.google.protobuf.Parser<TortugaOutput>
+        PARSER = new com.google.protobuf.AbstractParser<TortugaOutput>() {
+      public TortugaOutput parsePartialFrom(
+          com.google.protobuf.CodedInputStream input,
+          com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+          throws com.google.protobuf.InvalidProtocolBufferException {
+        return new TortugaOutput(input, extensionRegistry);
+      }
+    };
+
+    public static com.google.protobuf.Parser<TortugaOutput> parser() {
+      return PARSER;
+    }
+
+    @java.lang.Override
+    public com.google.protobuf.Parser<TortugaOutput> getParserForType() {
+      return PARSER;
+    }
+
+    public io.tortuga.TortugaParamsProto.TortugaOutput getDefaultInstanceForType() {
+      return DEFAULT_INSTANCE;
+    }
+
+  }
+
   public static final int BRIDGE_FIELD_NUMBER = 50007;
   /**
    * <code>extend .google.protobuf.MethodOptions { ... }</code>
@@ -511,6 +1081,11 @@ public final class TortugaParamsProto {
   private static final 
     com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
       internal_static_tortuga_TortugaBridgeOpts_fieldAccessorTable;
+  private static final com.google.protobuf.Descriptors.Descriptor
+    internal_static_tortuga_TortugaOutput_descriptor;
+  private static final 
+    com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
+      internal_static_tortuga_TortugaOutput_fieldAccessorTable;
 
   public static com.google.protobuf.Descriptors.FileDescriptor
       getDescriptor() {
@@ -522,10 +1097,11 @@ public final class TortugaParamsProto {
     java.lang.String[] descriptorData = {
       "\n\034tortuga/tortuga_params.proto\022\007tortuga\032" +
       " google/protobuf/descriptor.proto\",\n\021Tor" +
-      "tugaBridgeOpts\022\027\n\017timeout_seconds\030\001 \001(\005:" +
-      "L\n\006bridge\022\036.google.protobuf.MethodOption" +
-      "s\030\327\206\003 \001(\0132\032.tortuga.TortugaBridgeOptsB \n" +
-      "\nio.tortugaB\022TortugaParamsProto"
+      "tugaBridgeOpts\022\027\n\017timeout_seconds\030\001 \001(\005\"" +
+      "\037\n\rTortugaOutput\022\016\n\006output\030\001 \001(\t:L\n\006brid" +
+      "ge\022\036.google.protobuf.MethodOptions\030\327\206\003 \001" +
+      "(\0132\032.tortuga.TortugaBridgeOptsB \n\nio.tor" +
+      "tugaB\022TortugaParamsProto"
     };
     com.google.protobuf.Descriptors.FileDescriptor.InternalDescriptorAssigner assigner =
         new com.google.protobuf.Descriptors.FileDescriptor.    InternalDescriptorAssigner() {
@@ -546,6 +1122,12 @@ public final class TortugaParamsProto {
       com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
         internal_static_tortuga_TortugaBridgeOpts_descriptor,
         new java.lang.String[] { "TimeoutSeconds", });
+    internal_static_tortuga_TortugaOutput_descriptor =
+      getDescriptor().getMessageTypes().get(1);
+    internal_static_tortuga_TortugaOutput_fieldAccessorTable = new
+      com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
+        internal_static_tortuga_TortugaOutput_descriptor,
+        new java.lang.String[] { "Output", });
     bridge.internalInit(descriptor.getExtensions().get(0));
     com.google.protobuf.DescriptorProtos.getDescriptor();
   }

--- a/tortuga/test.proto
+++ b/tortuga/test.proto
@@ -8,6 +8,7 @@ option java_outer_classname = "TortugaProto";
 
 import "google/protobuf/empty.proto";
 import "google/protobuf/wrappers.proto";
+import "tortuga/tortuga_params.proto";
 
 message TestMessage {
   string id = 1;
@@ -20,5 +21,5 @@ service TestService {
 
 service TestService2 {
   rpc HandleTask2(google.protobuf.StringValue) returns (google.protobuf.Empty);
-  rpc HandleCustomMessage2(TestMessage) returns (google.protobuf.Empty);
+  rpc HandleCustomMessage2(TestMessage) returns (tortuga.TortugaOutput);
 }

--- a/tortuga/tortuga_params.pb.cc
+++ b/tortuga/tortuga_params.pb.cc
@@ -25,6 +25,11 @@ class TortugaBridgeOptsDefaultTypeInternal {
   ::google::protobuf::internal::ExplicitlyConstructed<TortugaBridgeOpts>
       _instance;
 } _TortugaBridgeOpts_default_instance_;
+class TortugaOutputDefaultTypeInternal {
+ public:
+  ::google::protobuf::internal::ExplicitlyConstructed<TortugaOutput>
+      _instance;
+} _TortugaOutput_default_instance_;
 }  // namespace tortuga
 namespace protobuf_tortuga_2ftortuga_5fparams_2eproto {
 void InitDefaultsTortugaBridgeOptsImpl() {
@@ -48,7 +53,28 @@ void InitDefaultsTortugaBridgeOpts() {
   ::google::protobuf::GoogleOnceInit(&once, &InitDefaultsTortugaBridgeOptsImpl);
 }
 
-::google::protobuf::Metadata file_level_metadata[1];
+void InitDefaultsTortugaOutputImpl() {
+  GOOGLE_PROTOBUF_VERIFY_VERSION;
+
+#ifdef GOOGLE_PROTOBUF_ENFORCE_UNIQUENESS
+  ::google::protobuf::internal::InitProtobufDefaultsForceUnique();
+#else
+  ::google::protobuf::internal::InitProtobufDefaults();
+#endif  // GOOGLE_PROTOBUF_ENFORCE_UNIQUENESS
+  {
+    void* ptr = &::tortuga::_TortugaOutput_default_instance_;
+    new (ptr) ::tortuga::TortugaOutput();
+    ::google::protobuf::internal::OnShutdownDestroyMessage(ptr);
+  }
+  ::tortuga::TortugaOutput::InitAsDefaultInstance();
+}
+
+void InitDefaultsTortugaOutput() {
+  static GOOGLE_PROTOBUF_DECLARE_ONCE(once);
+  ::google::protobuf::GoogleOnceInit(&once, &InitDefaultsTortugaOutputImpl);
+}
+
+::google::protobuf::Metadata file_level_metadata[2];
 
 const ::google::protobuf::uint32 TableStruct::offsets[] GOOGLE_PROTOBUF_ATTRIBUTE_SECTION_VARIABLE(protodesc_cold) = {
   GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(::tortuga::TortugaBridgeOpts, _has_bits_),
@@ -58,13 +84,22 @@ const ::google::protobuf::uint32 TableStruct::offsets[] GOOGLE_PROTOBUF_ATTRIBUT
   ~0u,  // no _weak_field_map_
   GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(::tortuga::TortugaBridgeOpts, timeout_seconds_),
   0,
+  GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(::tortuga::TortugaOutput, _has_bits_),
+  GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(::tortuga::TortugaOutput, _internal_metadata_),
+  ~0u,  // no _extensions_
+  ~0u,  // no _oneof_case_
+  ~0u,  // no _weak_field_map_
+  GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(::tortuga::TortugaOutput, output_),
+  0,
 };
 static const ::google::protobuf::internal::MigrationSchema schemas[] GOOGLE_PROTOBUF_ATTRIBUTE_SECTION_VARIABLE(protodesc_cold) = {
   { 0, 6, sizeof(::tortuga::TortugaBridgeOpts)},
+  { 7, 13, sizeof(::tortuga::TortugaOutput)},
 };
 
 static ::google::protobuf::Message const * const file_default_instances[] = {
   reinterpret_cast<const ::google::protobuf::Message*>(&::tortuga::_TortugaBridgeOpts_default_instance_),
+  reinterpret_cast<const ::google::protobuf::Message*>(&::tortuga::_TortugaOutput_default_instance_),
 };
 
 void protobuf_AssignDescriptors() {
@@ -83,7 +118,7 @@ void protobuf_AssignDescriptorsOnce() {
 void protobuf_RegisterTypes(const ::std::string&) GOOGLE_PROTOBUF_ATTRIBUTE_COLD;
 void protobuf_RegisterTypes(const ::std::string&) {
   protobuf_AssignDescriptorsOnce();
-  ::google::protobuf::internal::RegisterAllTypes(file_level_metadata, 1);
+  ::google::protobuf::internal::RegisterAllTypes(file_level_metadata, 2);
 }
 
 void AddDescriptorsImpl() {
@@ -91,13 +126,14 @@ void AddDescriptorsImpl() {
   static const char descriptor[] GOOGLE_PROTOBUF_ATTRIBUTE_SECTION_VARIABLE(protodesc_cold) = {
       "\n\034tortuga/tortuga_params.proto\022\007tortuga\032"
       " google/protobuf/descriptor.proto\",\n\021Tor"
-      "tugaBridgeOpts\022\027\n\017timeout_seconds\030\001 \001(\005:"
-      "L\n\006bridge\022\036.google.protobuf.MethodOption"
-      "s\030\327\206\003 \001(\0132\032.tortuga.TortugaBridgeOptsB \n"
-      "\nio.tortugaB\022TortugaParamsProto"
+      "tugaBridgeOpts\022\027\n\017timeout_seconds\030\001 \001(\005\""
+      "\037\n\rTortugaOutput\022\016\n\006output\030\001 \001(\t:L\n\006brid"
+      "ge\022\036.google.protobuf.MethodOptions\030\327\206\003 \001"
+      "(\0132\032.tortuga.TortugaBridgeOptsB \n\nio.tor"
+      "tugaB\022TortugaParamsProto"
   };
   ::google::protobuf::DescriptorPool::InternalAddGeneratedFile(
-      descriptor, 231);
+      descriptor, 264);
   ::google::protobuf::MessageFactory::InternalRegisterGeneratedFile(
     "tortuga/tortuga_params.proto", &protobuf_RegisterTypes);
   ::protobuf_google_2fprotobuf_2fdescriptor_2eproto::AddDescriptors();
@@ -354,6 +390,271 @@ void TortugaBridgeOpts::InternalSwap(TortugaBridgeOpts* other) {
 }
 
 ::google::protobuf::Metadata TortugaBridgeOpts::GetMetadata() const {
+  protobuf_tortuga_2ftortuga_5fparams_2eproto::protobuf_AssignDescriptorsOnce();
+  return ::protobuf_tortuga_2ftortuga_5fparams_2eproto::file_level_metadata[kIndexInFileMessages];
+}
+
+
+// ===================================================================
+
+void TortugaOutput::InitAsDefaultInstance() {
+}
+#if !defined(_MSC_VER) || _MSC_VER >= 1900
+const int TortugaOutput::kOutputFieldNumber;
+#endif  // !defined(_MSC_VER) || _MSC_VER >= 1900
+
+TortugaOutput::TortugaOutput()
+  : ::google::protobuf::Message(), _internal_metadata_(NULL) {
+  if (GOOGLE_PREDICT_TRUE(this != internal_default_instance())) {
+    ::protobuf_tortuga_2ftortuga_5fparams_2eproto::InitDefaultsTortugaOutput();
+  }
+  SharedCtor();
+  // @@protoc_insertion_point(constructor:tortuga.TortugaOutput)
+}
+TortugaOutput::TortugaOutput(const TortugaOutput& from)
+  : ::google::protobuf::Message(),
+      _internal_metadata_(NULL),
+      _has_bits_(from._has_bits_),
+      _cached_size_(0) {
+  _internal_metadata_.MergeFrom(from._internal_metadata_);
+  output_.UnsafeSetDefault(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
+  if (from.has_output()) {
+    output_.AssignWithDefault(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), from.output_);
+  }
+  // @@protoc_insertion_point(copy_constructor:tortuga.TortugaOutput)
+}
+
+void TortugaOutput::SharedCtor() {
+  _cached_size_ = 0;
+  output_.UnsafeSetDefault(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
+}
+
+TortugaOutput::~TortugaOutput() {
+  // @@protoc_insertion_point(destructor:tortuga.TortugaOutput)
+  SharedDtor();
+}
+
+void TortugaOutput::SharedDtor() {
+  output_.DestroyNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
+}
+
+void TortugaOutput::SetCachedSize(int size) const {
+  GOOGLE_SAFE_CONCURRENT_WRITES_BEGIN();
+  _cached_size_ = size;
+  GOOGLE_SAFE_CONCURRENT_WRITES_END();
+}
+const ::google::protobuf::Descriptor* TortugaOutput::descriptor() {
+  ::protobuf_tortuga_2ftortuga_5fparams_2eproto::protobuf_AssignDescriptorsOnce();
+  return ::protobuf_tortuga_2ftortuga_5fparams_2eproto::file_level_metadata[kIndexInFileMessages].descriptor;
+}
+
+const TortugaOutput& TortugaOutput::default_instance() {
+  ::protobuf_tortuga_2ftortuga_5fparams_2eproto::InitDefaultsTortugaOutput();
+  return *internal_default_instance();
+}
+
+TortugaOutput* TortugaOutput::New(::google::protobuf::Arena* arena) const {
+  TortugaOutput* n = new TortugaOutput;
+  if (arena != NULL) {
+    arena->Own(n);
+  }
+  return n;
+}
+
+void TortugaOutput::Clear() {
+// @@protoc_insertion_point(message_clear_start:tortuga.TortugaOutput)
+  ::google::protobuf::uint32 cached_has_bits = 0;
+  // Prevent compiler warnings about cached_has_bits being unused
+  (void) cached_has_bits;
+
+  cached_has_bits = _has_bits_[0];
+  if (cached_has_bits & 0x00000001u) {
+    GOOGLE_DCHECK(!output_.IsDefault(&::google::protobuf::internal::GetEmptyStringAlreadyInited()));
+    (*output_.UnsafeRawStringPointer())->clear();
+  }
+  _has_bits_.Clear();
+  _internal_metadata_.Clear();
+}
+
+bool TortugaOutput::MergePartialFromCodedStream(
+    ::google::protobuf::io::CodedInputStream* input) {
+#define DO_(EXPRESSION) if (!GOOGLE_PREDICT_TRUE(EXPRESSION)) goto failure
+  ::google::protobuf::uint32 tag;
+  // @@protoc_insertion_point(parse_start:tortuga.TortugaOutput)
+  for (;;) {
+    ::std::pair< ::google::protobuf::uint32, bool> p = input->ReadTagWithCutoffNoLastTag(127u);
+    tag = p.first;
+    if (!p.second) goto handle_unusual;
+    switch (::google::protobuf::internal::WireFormatLite::GetTagFieldNumber(tag)) {
+      // optional string output = 1;
+      case 1: {
+        if (static_cast< ::google::protobuf::uint8>(tag) ==
+            static_cast< ::google::protobuf::uint8>(10u /* 10 & 0xFF */)) {
+          DO_(::google::protobuf::internal::WireFormatLite::ReadString(
+                input, this->mutable_output()));
+          ::google::protobuf::internal::WireFormat::VerifyUTF8StringNamedField(
+            this->output().data(), static_cast<int>(this->output().length()),
+            ::google::protobuf::internal::WireFormat::PARSE,
+            "tortuga.TortugaOutput.output");
+        } else {
+          goto handle_unusual;
+        }
+        break;
+      }
+
+      default: {
+      handle_unusual:
+        if (tag == 0) {
+          goto success;
+        }
+        DO_(::google::protobuf::internal::WireFormat::SkipField(
+              input, tag, _internal_metadata_.mutable_unknown_fields()));
+        break;
+      }
+    }
+  }
+success:
+  // @@protoc_insertion_point(parse_success:tortuga.TortugaOutput)
+  return true;
+failure:
+  // @@protoc_insertion_point(parse_failure:tortuga.TortugaOutput)
+  return false;
+#undef DO_
+}
+
+void TortugaOutput::SerializeWithCachedSizes(
+    ::google::protobuf::io::CodedOutputStream* output) const {
+  // @@protoc_insertion_point(serialize_start:tortuga.TortugaOutput)
+  ::google::protobuf::uint32 cached_has_bits = 0;
+  (void) cached_has_bits;
+
+  cached_has_bits = _has_bits_[0];
+  // optional string output = 1;
+  if (cached_has_bits & 0x00000001u) {
+    ::google::protobuf::internal::WireFormat::VerifyUTF8StringNamedField(
+      this->output().data(), static_cast<int>(this->output().length()),
+      ::google::protobuf::internal::WireFormat::SERIALIZE,
+      "tortuga.TortugaOutput.output");
+    ::google::protobuf::internal::WireFormatLite::WriteStringMaybeAliased(
+      1, this->output(), output);
+  }
+
+  if (_internal_metadata_.have_unknown_fields()) {
+    ::google::protobuf::internal::WireFormat::SerializeUnknownFields(
+        _internal_metadata_.unknown_fields(), output);
+  }
+  // @@protoc_insertion_point(serialize_end:tortuga.TortugaOutput)
+}
+
+::google::protobuf::uint8* TortugaOutput::InternalSerializeWithCachedSizesToArray(
+    bool deterministic, ::google::protobuf::uint8* target) const {
+  (void)deterministic; // Unused
+  // @@protoc_insertion_point(serialize_to_array_start:tortuga.TortugaOutput)
+  ::google::protobuf::uint32 cached_has_bits = 0;
+  (void) cached_has_bits;
+
+  cached_has_bits = _has_bits_[0];
+  // optional string output = 1;
+  if (cached_has_bits & 0x00000001u) {
+    ::google::protobuf::internal::WireFormat::VerifyUTF8StringNamedField(
+      this->output().data(), static_cast<int>(this->output().length()),
+      ::google::protobuf::internal::WireFormat::SERIALIZE,
+      "tortuga.TortugaOutput.output");
+    target =
+      ::google::protobuf::internal::WireFormatLite::WriteStringToArray(
+        1, this->output(), target);
+  }
+
+  if (_internal_metadata_.have_unknown_fields()) {
+    target = ::google::protobuf::internal::WireFormat::SerializeUnknownFieldsToArray(
+        _internal_metadata_.unknown_fields(), target);
+  }
+  // @@protoc_insertion_point(serialize_to_array_end:tortuga.TortugaOutput)
+  return target;
+}
+
+size_t TortugaOutput::ByteSizeLong() const {
+// @@protoc_insertion_point(message_byte_size_start:tortuga.TortugaOutput)
+  size_t total_size = 0;
+
+  if (_internal_metadata_.have_unknown_fields()) {
+    total_size +=
+      ::google::protobuf::internal::WireFormat::ComputeUnknownFieldsSize(
+        _internal_metadata_.unknown_fields());
+  }
+  // optional string output = 1;
+  if (has_output()) {
+    total_size += 1 +
+      ::google::protobuf::internal::WireFormatLite::StringSize(
+        this->output());
+  }
+
+  int cached_size = ::google::protobuf::internal::ToCachedSize(total_size);
+  GOOGLE_SAFE_CONCURRENT_WRITES_BEGIN();
+  _cached_size_ = cached_size;
+  GOOGLE_SAFE_CONCURRENT_WRITES_END();
+  return total_size;
+}
+
+void TortugaOutput::MergeFrom(const ::google::protobuf::Message& from) {
+// @@protoc_insertion_point(generalized_merge_from_start:tortuga.TortugaOutput)
+  GOOGLE_DCHECK_NE(&from, this);
+  const TortugaOutput* source =
+      ::google::protobuf::internal::DynamicCastToGenerated<const TortugaOutput>(
+          &from);
+  if (source == NULL) {
+  // @@protoc_insertion_point(generalized_merge_from_cast_fail:tortuga.TortugaOutput)
+    ::google::protobuf::internal::ReflectionOps::Merge(from, this);
+  } else {
+  // @@protoc_insertion_point(generalized_merge_from_cast_success:tortuga.TortugaOutput)
+    MergeFrom(*source);
+  }
+}
+
+void TortugaOutput::MergeFrom(const TortugaOutput& from) {
+// @@protoc_insertion_point(class_specific_merge_from_start:tortuga.TortugaOutput)
+  GOOGLE_DCHECK_NE(&from, this);
+  _internal_metadata_.MergeFrom(from._internal_metadata_);
+  ::google::protobuf::uint32 cached_has_bits = 0;
+  (void) cached_has_bits;
+
+  if (from.has_output()) {
+    set_has_output();
+    output_.AssignWithDefault(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), from.output_);
+  }
+}
+
+void TortugaOutput::CopyFrom(const ::google::protobuf::Message& from) {
+// @@protoc_insertion_point(generalized_copy_from_start:tortuga.TortugaOutput)
+  if (&from == this) return;
+  Clear();
+  MergeFrom(from);
+}
+
+void TortugaOutput::CopyFrom(const TortugaOutput& from) {
+// @@protoc_insertion_point(class_specific_copy_from_start:tortuga.TortugaOutput)
+  if (&from == this) return;
+  Clear();
+  MergeFrom(from);
+}
+
+bool TortugaOutput::IsInitialized() const {
+  return true;
+}
+
+void TortugaOutput::Swap(TortugaOutput* other) {
+  if (other == this) return;
+  InternalSwap(other);
+}
+void TortugaOutput::InternalSwap(TortugaOutput* other) {
+  using std::swap;
+  output_.Swap(&other->output_);
+  swap(_has_bits_[0], other->_has_bits_[0]);
+  _internal_metadata_.Swap(&other->_internal_metadata_);
+  swap(_cached_size_, other->_cached_size_);
+}
+
+::google::protobuf::Metadata TortugaOutput::GetMetadata() const {
   protobuf_tortuga_2ftortuga_5fparams_2eproto::protobuf_AssignDescriptorsOnce();
   return ::protobuf_tortuga_2ftortuga_5fparams_2eproto::file_level_metadata[kIndexInFileMessages];
 }

--- a/tortuga/tortuga_params.pb.h
+++ b/tortuga/tortuga_params.pb.h
@@ -37,7 +37,7 @@ namespace protobuf_tortuga_2ftortuga_5fparams_2eproto {
 struct TableStruct {
   static const ::google::protobuf::internal::ParseTableField entries[];
   static const ::google::protobuf::internal::AuxillaryParseTableField aux[];
-  static const ::google::protobuf::internal::ParseTable schema[1];
+  static const ::google::protobuf::internal::ParseTable schema[2];
   static const ::google::protobuf::internal::FieldMetadata field_metadata[];
   static const ::google::protobuf::internal::SerializationTable serialization_table[];
   static const ::google::protobuf::uint32 offsets[];
@@ -45,14 +45,20 @@ struct TableStruct {
 void AddDescriptors();
 void InitDefaultsTortugaBridgeOptsImpl();
 void InitDefaultsTortugaBridgeOpts();
+void InitDefaultsTortugaOutputImpl();
+void InitDefaultsTortugaOutput();
 inline void InitDefaults() {
   InitDefaultsTortugaBridgeOpts();
+  InitDefaultsTortugaOutput();
 }
 }  // namespace protobuf_tortuga_2ftortuga_5fparams_2eproto
 namespace tortuga {
 class TortugaBridgeOpts;
 class TortugaBridgeOptsDefaultTypeInternal;
 extern TortugaBridgeOptsDefaultTypeInternal _TortugaBridgeOpts_default_instance_;
+class TortugaOutput;
+class TortugaOutputDefaultTypeInternal;
+extern TortugaOutputDefaultTypeInternal _TortugaOutput_default_instance_;
 }  // namespace tortuga
 namespace tortuga {
 
@@ -166,6 +172,124 @@ class TortugaBridgeOpts : public ::google::protobuf::Message /* @@protoc_inserti
   friend struct ::protobuf_tortuga_2ftortuga_5fparams_2eproto::TableStruct;
   friend void ::protobuf_tortuga_2ftortuga_5fparams_2eproto::InitDefaultsTortugaBridgeOptsImpl();
 };
+// -------------------------------------------------------------------
+
+class TortugaOutput : public ::google::protobuf::Message /* @@protoc_insertion_point(class_definition:tortuga.TortugaOutput) */ {
+ public:
+  TortugaOutput();
+  virtual ~TortugaOutput();
+
+  TortugaOutput(const TortugaOutput& from);
+
+  inline TortugaOutput& operator=(const TortugaOutput& from) {
+    CopyFrom(from);
+    return *this;
+  }
+  #if LANG_CXX11
+  TortugaOutput(TortugaOutput&& from) noexcept
+    : TortugaOutput() {
+    *this = ::std::move(from);
+  }
+
+  inline TortugaOutput& operator=(TortugaOutput&& from) noexcept {
+    if (GetArenaNoVirtual() == from.GetArenaNoVirtual()) {
+      if (this != &from) InternalSwap(&from);
+    } else {
+      CopyFrom(from);
+    }
+    return *this;
+  }
+  #endif
+  inline const ::google::protobuf::UnknownFieldSet& unknown_fields() const {
+    return _internal_metadata_.unknown_fields();
+  }
+  inline ::google::protobuf::UnknownFieldSet* mutable_unknown_fields() {
+    return _internal_metadata_.mutable_unknown_fields();
+  }
+
+  static const ::google::protobuf::Descriptor* descriptor();
+  static const TortugaOutput& default_instance();
+
+  static void InitAsDefaultInstance();  // FOR INTERNAL USE ONLY
+  static inline const TortugaOutput* internal_default_instance() {
+    return reinterpret_cast<const TortugaOutput*>(
+               &_TortugaOutput_default_instance_);
+  }
+  static PROTOBUF_CONSTEXPR int const kIndexInFileMessages =
+    1;
+
+  void Swap(TortugaOutput* other);
+  friend void swap(TortugaOutput& a, TortugaOutput& b) {
+    a.Swap(&b);
+  }
+
+  // implements Message ----------------------------------------------
+
+  inline TortugaOutput* New() const PROTOBUF_FINAL { return New(NULL); }
+
+  TortugaOutput* New(::google::protobuf::Arena* arena) const PROTOBUF_FINAL;
+  void CopyFrom(const ::google::protobuf::Message& from) PROTOBUF_FINAL;
+  void MergeFrom(const ::google::protobuf::Message& from) PROTOBUF_FINAL;
+  void CopyFrom(const TortugaOutput& from);
+  void MergeFrom(const TortugaOutput& from);
+  void Clear() PROTOBUF_FINAL;
+  bool IsInitialized() const PROTOBUF_FINAL;
+
+  size_t ByteSizeLong() const PROTOBUF_FINAL;
+  bool MergePartialFromCodedStream(
+      ::google::protobuf::io::CodedInputStream* input) PROTOBUF_FINAL;
+  void SerializeWithCachedSizes(
+      ::google::protobuf::io::CodedOutputStream* output) const PROTOBUF_FINAL;
+  ::google::protobuf::uint8* InternalSerializeWithCachedSizesToArray(
+      bool deterministic, ::google::protobuf::uint8* target) const PROTOBUF_FINAL;
+  int GetCachedSize() const PROTOBUF_FINAL { return _cached_size_; }
+  private:
+  void SharedCtor();
+  void SharedDtor();
+  void SetCachedSize(int size) const PROTOBUF_FINAL;
+  void InternalSwap(TortugaOutput* other);
+  private:
+  inline ::google::protobuf::Arena* GetArenaNoVirtual() const {
+    return NULL;
+  }
+  inline void* MaybeArenaPtr() const {
+    return NULL;
+  }
+  public:
+
+  ::google::protobuf::Metadata GetMetadata() const PROTOBUF_FINAL;
+
+  // nested types ----------------------------------------------------
+
+  // accessors -------------------------------------------------------
+
+  // optional string output = 1;
+  bool has_output() const;
+  void clear_output();
+  static const int kOutputFieldNumber = 1;
+  const ::std::string& output() const;
+  void set_output(const ::std::string& value);
+  #if LANG_CXX11
+  void set_output(::std::string&& value);
+  #endif
+  void set_output(const char* value);
+  void set_output(const char* value, size_t size);
+  ::std::string* mutable_output();
+  ::std::string* release_output();
+  void set_allocated_output(::std::string* output);
+
+  // @@protoc_insertion_point(class_scope:tortuga.TortugaOutput)
+ private:
+  void set_has_output();
+  void clear_has_output();
+
+  ::google::protobuf::internal::InternalMetadataWithArena _internal_metadata_;
+  ::google::protobuf::internal::HasBits<1> _has_bits_;
+  mutable int _cached_size_;
+  ::google::protobuf::internal::ArenaStringPtr output_;
+  friend struct ::protobuf_tortuga_2ftortuga_5fparams_2eproto::TableStruct;
+  friend void ::protobuf_tortuga_2ftortuga_5fparams_2eproto::InitDefaultsTortugaOutputImpl();
+};
 // ===================================================================
 
 static const int kBridgeFieldNumber = 50007;
@@ -205,9 +329,78 @@ inline void TortugaBridgeOpts::set_timeout_seconds(::google::protobuf::int32 val
   // @@protoc_insertion_point(field_set:tortuga.TortugaBridgeOpts.timeout_seconds)
 }
 
+// -------------------------------------------------------------------
+
+// TortugaOutput
+
+// optional string output = 1;
+inline bool TortugaOutput::has_output() const {
+  return (_has_bits_[0] & 0x00000001u) != 0;
+}
+inline void TortugaOutput::set_has_output() {
+  _has_bits_[0] |= 0x00000001u;
+}
+inline void TortugaOutput::clear_has_output() {
+  _has_bits_[0] &= ~0x00000001u;
+}
+inline void TortugaOutput::clear_output() {
+  output_.ClearToEmptyNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
+  clear_has_output();
+}
+inline const ::std::string& TortugaOutput::output() const {
+  // @@protoc_insertion_point(field_get:tortuga.TortugaOutput.output)
+  return output_.GetNoArena();
+}
+inline void TortugaOutput::set_output(const ::std::string& value) {
+  set_has_output();
+  output_.SetNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), value);
+  // @@protoc_insertion_point(field_set:tortuga.TortugaOutput.output)
+}
+#if LANG_CXX11
+inline void TortugaOutput::set_output(::std::string&& value) {
+  set_has_output();
+  output_.SetNoArena(
+    &::google::protobuf::internal::GetEmptyStringAlreadyInited(), ::std::move(value));
+  // @@protoc_insertion_point(field_set_rvalue:tortuga.TortugaOutput.output)
+}
+#endif
+inline void TortugaOutput::set_output(const char* value) {
+  GOOGLE_DCHECK(value != NULL);
+  set_has_output();
+  output_.SetNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), ::std::string(value));
+  // @@protoc_insertion_point(field_set_char:tortuga.TortugaOutput.output)
+}
+inline void TortugaOutput::set_output(const char* value, size_t size) {
+  set_has_output();
+  output_.SetNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited(),
+      ::std::string(reinterpret_cast<const char*>(value), size));
+  // @@protoc_insertion_point(field_set_pointer:tortuga.TortugaOutput.output)
+}
+inline ::std::string* TortugaOutput::mutable_output() {
+  set_has_output();
+  // @@protoc_insertion_point(field_mutable:tortuga.TortugaOutput.output)
+  return output_.MutableNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
+}
+inline ::std::string* TortugaOutput::release_output() {
+  // @@protoc_insertion_point(field_release:tortuga.TortugaOutput.output)
+  clear_has_output();
+  return output_.ReleaseNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
+}
+inline void TortugaOutput::set_allocated_output(::std::string* output) {
+  if (output != NULL) {
+    set_has_output();
+  } else {
+    clear_has_output();
+  }
+  output_.SetAllocatedNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), output);
+  // @@protoc_insertion_point(field_set_allocated:tortuga.TortugaOutput.output)
+}
+
 #ifdef __GNUC__
   #pragma GCC diagnostic pop
 #endif  // __GNUC__
+// -------------------------------------------------------------------
+
 
 // @@protoc_insertion_point(namespace_scope)
 

--- a/tortuga/tortuga_params.proto
+++ b/tortuga/tortuga_params.proto
@@ -17,7 +17,7 @@ extend google.protobuf.MethodOptions {
   optional TortugaBridgeOpts bridge = 50007;
 }
 
-// This message is to be used by tortuga <> GRPR bridge.
+// This message is to be used by tortuga <> GRPC bridge.
 // If and only if the service returns this Type, and 'output' is not empty, then the
 // tortuga bridge will write this as output of the task.
 message TortugaOutput {

--- a/tortuga/tortuga_params.proto
+++ b/tortuga/tortuga_params.proto
@@ -16,3 +16,10 @@ message TortugaBridgeOpts {
 extend google.protobuf.MethodOptions {
   optional TortugaBridgeOpts bridge = 50007;
 }
+
+// This message is to be used by tortuga <> GRPR bridge.
+// If and only if the service returns this Type, and 'output' is not empty, then the
+// tortuga bridge will write this as output of the task.
+message TortugaOutput {
+  optional string output = 1;
+}


### PR DESCRIPTION
If and only if the GRPC service returns type tortuga.TortugaOutput, it will be set
as the task output.