### PR TITLE
Create task on firestore as soon as it is created

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -28,6 +28,9 @@ java_test(
         "src/test/java/io/tortuga/TortugaIntegrationTest.java",
     ],
     test_class = "io.tortuga.TortugaIntegrationTest",
+    tags = [
+        "exclusive"
+    ],
     deps = [
         ":com_google_guava_guava",
         ":com_google_protobuf_protobuf_java",

--- a/tortuga/modules/firestore.cc
+++ b/tortuga/modules/firestore.cc
@@ -48,6 +48,12 @@ void FirestoreModule::OnProgressUpdate(const TaskProgress& task) {
   }
 
   {
+    Value worked_on_value;
+    worked_on_value.set_boolean_value(task.worked_on());
+    (*fields)["worked_on"] = worked_on_value;
+  }
+
+  {
     Value progress_value;
     progress_value.set_double_value(static_cast<double>(task.progress()));
     (*fields)["progress"] = progress_value;

--- a/tortuga/tortuga.cc
+++ b/tortuga/tortuga.cc
@@ -600,7 +600,7 @@ void TortugaHandler::MaybeNotifyModulesOfUpdate(const UpdatedTask& task) {
 void TortugaHandler::MaybeNotifyModulesOfCreation(const std::string& handle,
                                                   const std::vector<std::string> modules) {
   TaskProgress progress;
-  progress.set_id(handle);
+  progress.set_handle(handle);
   *progress.mutable_created() = TimeUtil::GetCurrentTime();
   // any remaining fields as defaults is fine (worked_on = false etc...).
 

--- a/tortuga/tortuga.h
+++ b/tortuga/tortuga.h
@@ -88,7 +88,9 @@ class TortugaHandler : boost::noncopyable {
   UpdatedTask* UpdateProgress(const UpdateProgressReq& req);
   UpdatedTask* UpdateProgressInExec(const UpdateProgressReq& req);
 
-  void MaybeNotifyModules(const UpdatedTask& task);
+  void MaybeNotifyModulesOfUpdate(const UpdatedTask& task);
+  void MaybeNotifyModulesOfCreation(const std::string& handle,
+                                    const std::vector<std::string> modules);
   void UpdateProgressManagerCache(const UpdatedTask& task);
 
   // Caller doesn't take ownership.


### PR DESCRIPTION
This shall make the frontend life easier as they can start
listening on the task key for changes without fear of
the firestore bugs than happen when a key doesn't exist.